### PR TITLE
enable current title on remote

### DIFF
--- a/fs42/remote/commands.py
+++ b/fs42/remote/commands.py
@@ -13,12 +13,13 @@ def read_status():
             status = json.loads(line)
             return {
                 "channel": status.get("channel_number", -1),
-                "name": status.get("network_name", "")
+                "name": status.get("network_name", ""),
+                "title": status.get("title", ""),
             }
     except Exception as e:
         traceback.print_exc()
         return {"channel": -1, "name": ""}
-    
+
 def write_command(message: dict):
     """Takes a dictionary command"""
     message = json.dumps(message) + "\n"

--- a/fs42/remote/static/index.html
+++ b/fs42/remote/static/index.html
@@ -39,5 +39,7 @@
     <button class="btn" onclick="appendDigit(0)">0</button>
     <button class="btn" onclick="sendDirect(true)">Enter</button>
   </div>
+
+  <div id="title"></div>
 </body>
 </html>

--- a/fs42/remote/static/remote.css
+++ b/fs42/remote/static/remote.css
@@ -6,7 +6,7 @@ html, body {
     overflow: hidden;
     touch-action: manipulation;
   }
-  
+
   .btn {
     font-size: 1.5em;
     margin: 5px;
@@ -21,26 +21,26 @@ html, body {
   .btn:hover {
     background: #666;
   }
-  
+
   .btn-flex {
     display: flex;
     align-items: center;
     justify-content: flex-start;
     text-align: left;
   }
-  
+
   .btn-flex .arrow {
     flex: 0 0 auto;
     margin-left: 8px;
     font-size: 1.5em;
   }
-  
+
   .btn-flex .label {
     flex: 1;
     text-align: center;
   }
 
-  
+
   .seven-seg {
     font-family: 'Courier New', monospace;
     font-size: 4em;
@@ -53,7 +53,7 @@ html, body {
     max-width: 300px;
     text-align: center;
   }
-  
+
   #network-name {
     color: #aaa;
     font-size: 1.2em;
@@ -62,7 +62,7 @@ html, body {
     margin-top: 5px;
     text-align: center;
   }
-  
+
   .row {
     display: flex;
     justify-content: center;
@@ -70,7 +70,7 @@ html, body {
     max-width: 300px;
     margin: 0 auto;
   }
-  
+
   .keypad {
     display: flex;
     flex-wrap: wrap;
@@ -79,17 +79,33 @@ html, body {
     max-width: 300px;
     margin: 10px auto 5px auto;
   }
-  
+
   .keypad .btn {
     width: calc(33.333% - 10px);
     margin: 5px;
     box-sizing: border-box;
   }
-  
+
   #entry {
     font-size: 2em;
     margin: 10px;
     color: #0f0;
     text-align: center;
   }
-  
+
+  /* Added styles for the current title */
+  #title {
+    color: #15cc24; /* Light gray, adjust as needed */
+    font-size: 1em;
+    text-align: center;
+    margin-top: 15px; /* Space above the title */
+    margin-bottom: 10px; /* Space below the title */
+    padding: 0 10px; /* Horizontal padding */
+    height: 2.4em; /* Approx 2 lines of text, adjust as needed */
+    overflow: hidden; /* Prevents long titles from breaking layout */
+    text-overflow: ellipsis; /* Shows ... for very long titles */
+    white-space: normal; /* Allow text to wrap if needed, though height will limit it */
+    max-width: 300px; /* Match keypad width */
+    margin-left: auto;
+    margin-right: auto;
+  }

--- a/fs42/remote/static/remote.js
+++ b/fs42/remote/static/remote.js
@@ -43,7 +43,7 @@ function sendDirect(force) {
     if (force || entryBuffer.length > 0) clearEntry();
 }
 
-function updateStatusDisplay(data) {    
+function updateStatusDisplay(data) {
     if (data.channel != null && data.channel >= 1) {
     document.getElementById("current-channel").innerText = data.channel.toString().padStart(2, "0");
     } else {
@@ -51,6 +51,8 @@ function updateStatusDisplay(data) {
     }
 
     document.getElementById("network-name").innerText = data.name || "";
+    document.getElementById("title").innerText = data.title || ""; // Added this line
+
 }
 
 function updateStatus() {


### PR DESCRIPTION
I tried to ensure nothing else was affected  by the updates, but I may be missing things.  This is my attempt to add the feature, i have it working in my env.

This pull request introduces changes to enhance the functionality of the media player by adding support for displaying the current title of the playing media. Key changes include updates to the player logic, status socket, and user interface to incorporate this new feature.

### Enhancements to Player Logic:
* Updated the `StationPlayer` class to track the currently playing file and extract its title. A new method, `get_current_title`, was added to retrieve the title of the current media file. (`fs42/station_player.py`, [[1]](diffhunk://#diff-4c27d188f4feb845f16f13f6c56bbca9bd58b3be4b7142a8e2b8449670eba9d3L63-R76) [[2]](diffhunk://#diff-4c27d188f4feb845f16f13f6c56bbca9bd58b3be4b7142a8e2b8449670eba9d3R92-R99) [[3]](diffhunk://#diff-4c27d188f4feb845f16f13f6c56bbca9bd58b3be4b7142a8e2b8449670eba9d3R183-R191)
* Modified the `play_file` method to update the status socket with the title of the media being played. (`fs42/station_player.py`, [fs42/station_player.pyR92-R99](diffhunk://#diff-4c27d188f4feb845f16f13f6c56bbca9bd58b3be4b7142a8e2b8449670eba9d3R92-R99))
* Replaced direct calls to `mpv.play` with the new `play_file` method to ensure title updates are handled consistently. (`fs42/station_player.py`, [fs42/station_player.pyL135-R149](diffhunk://#diff-4c27d188f4feb845f16f13f6c56bbca9bd58b3be4b7142a8e2b8449670eba9d3L135-R149))

### Status Socket Updates:
* Enhanced the `update_status_socket` function to include an optional `title` parameter, allowing the current title to be sent along with other status updates. (`fs42/station_player.py`, [fs42/station_player.pyL27-R36](diffhunk://#diff-4c27d188f4feb845f16f13f6c56bbca9bd58b3be4b7142a8e2b8449670eba9d3L27-R36))
* Updated the `field_player.py` logic to include the current title when sending "playing" and "stuck" status updates. (`field_player.py`, [[1]](diffhunk://#diff-1574214695f623b6c1d4d1f70118e2991248e5f4418fe90e7158945d2cec1c0dL62-R63) [[2]](diffhunk://#diff-1574214695f623b6c1d4d1f70118e2991248e5f4418fe90e7158945d2cec1c0dL136-R139)

### User Interface Improvements:
* Added a new `#title` element in the HTML to display the current title on the remote control interface. (`fs42/remote/static/index.html`, [fs42/remote/static/index.htmlR42-R43](diffhunk://#diff-0b42a50b90c43315814d4a773efaa54fa67a07f4791536e165818672c88bdafbR42-R43))
* Styled the `#title` element to ensure proper display and layout, including handling long titles with ellipsis. (`fs42/remote/static/remote.css`, [fs42/remote/static/remote.cssR96-R111](diffhunk://#diff-166f2dbe4ac4dc294d64a3e6e35cce976300c9160189e4d6a6f5df9c837f865dR96-R111))
* Updated the JavaScript `updateStatusDisplay` function to populate the `#title` element with the current title from the status data. (`fs42/remote/static/remote.js`, [fs42/remote/static/remote.jsR54-R55](diffhunk://#diff-3e13293e7d0a5637f22c76d69e6f21683a28ff9a3df68a9f2b19f9c505cfd6a2R54-R55))

### Additional Changes:
* Updated the `read_status` function to parse the `title` field from the status JSON. (`fs42/remote/commands.py`, [fs42/remote/commands.pyL16-R17](diffhunk://#diff-4ccdbe9bc49d94eabec012c257659785a8920eaef63a948b531ea8ae2d6d6f4dL16-R17))
* Adjusted the `StationPlayer` constructor to accept `station_config` instead of `runtime_path`, aligning with the new design. (`fs42/station_player.py`, [fs42/station_player.pyL54-R57](diffhunk://#diff-4c27d188f4feb845f16f13f6c56bbca9bd58b3be4b7142a8e2b8449670eba9d3L54-R57))
![image](https://github.com/user-attachments/assets/edd66b86-dc7c-4c9e-bf2f-a3662767a352)
