### PR TITLE
Update LogoDisplay check_status

### DIFF
--- a/fs42/osd/main.py
+++ b/fs42/osd/main.py
@@ -117,10 +117,16 @@ class LogoDisplay(object):
                 status = f.read()
                 status = json.loads(status)
 
-                if status != self.current_channel_info:
+                current_network = self.current_channel_info.get("network_name")
+                new_network = status.get("network_name")
+                
+                if new_network != current_network:
                     self.current_channel_info = status
                     self.time_since_change = 0
                     self.load_logo_for_channel(status)
+                else:
+                    self.current_channel_info = status
+                    
         except Exception as e:
             print(f"Unable to parse player status for logo: {e}")
 


### PR DESCRIPTION
Fixed detection method for when to update the Logo. Previous method was updating on any change to player_status.socket resulting on triggers on content change such as going to commercial. Now specifically look for the channel_name to change.