### PR TITLE
Catalog Iteration - File Meta Cache

### DIFF
--- a/fs42/catalog.py
+++ b/fs42/catalog.py
@@ -221,7 +221,9 @@ class ShowCatalog:
             self.clip_index[tag] = MediaProcessor._process_media(file_list, tag, fluid=self.__fluid_builder)
             self._l.info(f"--Found {len(self.clip_index[tag])} videos in {tag} folder")
             self._l.debug(f"---- {tag} media listing: {self.clip_index[tag]}")
-            subdir_clips = MediaProcessor._process_subs(tag_dir, tag, bumpdir=is_bumps)
+
+            subdir_clips = MediaProcessor._process_subs(tag_dir, tag, bumpdir=is_bumps, fluid=self.__fluid_builder)
+            
             self._l.info(f"--Found {len(subdir_clips)} videos in {tag} subfolders")
             self._l.debug(f"---- {tag} sub folder media listing: {subdir_clips}")
 

--- a/fs42/catalog.py
+++ b/fs42/catalog.py
@@ -16,6 +16,8 @@ except ImportError:
     from moviepy.editor import VideoFileClip  # type: ignore
 
 
+FF_USE_FLUID_FILE_CACHE = True
+
 class bcolors:
     HEADER = "\033[95m"
     OKBLUE = "\033[94m"
@@ -42,6 +44,8 @@ class ShowCatalog:
         self.sequences = {}
         # basically, a flattened list of clip_index keys
         self.tags = []
+
+        self.__fluid_builder = None
 
         if rebuild_catalog:
             self.build_catalog()
@@ -84,6 +88,14 @@ class ShowCatalog:
 
         match self.config["network_type"]:
             case "standard":
+                if FF_USE_FLUID_FILE_CACHE:
+                    from fs42.fluid_builder import FluidBuilder
+
+                    self.__fluid_builder = FluidBuilder()
+                    self._l.info("Initializing fluid file cache...")
+                    self.__fluid_builder.scan_file_cache(self.config["content_dir"])
+                    self._l.info("Fluid file cache updated - continuing build")
+
                 return self._build_standard()
             case "loop":
                 return self._build_single()
@@ -140,7 +152,7 @@ class ShowCatalog:
         # collect start and end bumps first
         for fp in start_bumps:
             path = f"{self.config['content_dir']}/{fp}"
-            sb = MediaProcessor._process_media([path], "start_bumps")
+            sb = MediaProcessor._process_media([path], "start_bumps", fluid=self.__fluid_builder)
             if len(sb) == 1:
                 self.clip_index["start_bumps"][fp] = sb[0]
             else:
@@ -149,7 +161,7 @@ class ShowCatalog:
 
         for fp in end_bumps:
             path = f"{self.config['content_dir']}/{fp}"
-            eb = MediaProcessor._process_media([path], "end_bumps")
+            eb = MediaProcessor._process_media([path], "end_bumps", fluid=self.__fluid_builder)
             if len(sb) == 1:
                 self.clip_index["end_bumps"][fp] = eb[0]
             else:
@@ -206,7 +218,7 @@ class ShowCatalog:
             tag_dir = f"{self.config['content_dir']}/{tag}"
             file_list = MediaProcessor._find_media(tag_dir)
 
-            self.clip_index[tag] = MediaProcessor._process_media(file_list, tag)
+            self.clip_index[tag] = MediaProcessor._process_media(file_list, tag, fluid=self.__fluid_builder)
             self._l.info(f"--Found {len(self.clip_index[tag])} videos in {tag} folder")
             self._l.debug(f"---- {tag} media listing: {self.clip_index[tag]}")
             subdir_clips = MediaProcessor._process_subs(tag_dir, tag, bumpdir=is_bumps)

--- a/fs42/fluid_builder.py
+++ b/fs42/fluid_builder.py
@@ -1,0 +1,45 @@
+import logging
+import sqlite3
+import sys
+import os
+sys.path.append(os.getcwd())
+
+from fs42.fluid_statements import FluidStatements
+from fs42.media_processor import MediaProcessor
+class FluidBuilder:
+    def __init__(self):
+        self.db_path = "runtime/fs42_fluid.db"
+        with sqlite3.connect(self.db_path) as connection:
+            FluidStatements.init_db(connection)
+
+    def scan_file_cache(self, content_dir):
+        with sqlite3.connect(self.db_path) as connection:
+            # read all the files in the content dir
+            logging.getLogger().info(f"Fluid file cache scan - reading {content_dir}")
+            file_list = MediaProcessor.rich_find_media(content_dir)
+            logging.getLogger().info(f"Comparing cache against {len(file_list)} files")
+            # add any that aren't there yet
+            FluidStatements.iterate_file_entries(connection, file_list)
+            logging.getLogger("FLUID").info("Checking file meta for stale entries.")
+            connection.commit()
+
+    def check_file_cache(self, full_path):
+        with sqlite3.connect(self.db_path) as connection:
+            results = FluidStatements.check_file_cache(connection, full_path)
+            connection.commit()
+    
+        return results
+    
+    def trim_file_cache(self):
+        with sqlite3.connect(self.db_path) as connection:
+            logging.getLogger().info("Trimming fluid file cache")
+            FluidStatements.trim_file_entries(connection)
+            connection.commit()            
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(levelname)s:%(name)s:%(message)s', level=logging.INFO)
+    builder = FluidBuilder()
+    builder.scan_file_cache("catalog/nbc_content/")
+    exists = builder.check_file_cache("/home/wrongdog/FieldStation42/catalog/public_domain/bextra/post-black.mov")
+

--- a/fs42/fluid_builder.py
+++ b/fs42/fluid_builder.py
@@ -44,4 +44,4 @@ if __name__ == "__main__":
     logging.basicConfig(format="%(levelname)s:%(name)s:%(message)s", level=logging.INFO)
     builder = FluidBuilder()
     builder.scan_file_cache("catalog/nbc_content/")
-    exists = builder.check_file_cache("/home/wrongdog/FieldStation42/catalog/public_domain/bextra/post-black.mov")
+    exists = builder.check_file_cache("FieldStation42/catalog/public_domain/bextra/post-black.mov")

--- a/fs42/fluid_builder.py
+++ b/fs42/fluid_builder.py
@@ -2,10 +2,13 @@ import logging
 import sqlite3
 import sys
 import os
+
 sys.path.append(os.getcwd())
 
 from fs42.fluid_statements import FluidStatements
 from fs42.media_processor import MediaProcessor
+
+
 class FluidBuilder:
     def __init__(self):
         self.db_path = "runtime/fs42_fluid.db"
@@ -27,19 +30,18 @@ class FluidBuilder:
         with sqlite3.connect(self.db_path) as connection:
             results = FluidStatements.check_file_cache(connection, full_path)
             connection.commit()
-    
+
         return results
-    
-    def trim_file_cache(self):
+
+    def trim_file_cache(self, from_time):
         with sqlite3.connect(self.db_path) as connection:
             logging.getLogger().info("Trimming fluid file cache")
-            FluidStatements.trim_file_entries(connection)
-            connection.commit()            
+            FluidStatements.trim_file_entries(connection, from_time)
+            connection.commit()
 
 
 if __name__ == "__main__":
-    logging.basicConfig(format='%(levelname)s:%(name)s:%(message)s', level=logging.INFO)
+    logging.basicConfig(format="%(levelname)s:%(name)s:%(message)s", level=logging.INFO)
     builder = FluidBuilder()
     builder.scan_file_cache("catalog/nbc_content/")
     exists = builder.check_file_cache("/home/wrongdog/FieldStation42/catalog/public_domain/bextra/post-black.mov")
-

--- a/fs42/fluid_objects.py
+++ b/fs42/fluid_objects.py
@@ -1,0 +1,49 @@
+import datetime
+
+
+class FileRepoEntry:
+    def __init__(self, db_row=None):
+        if not db_row:
+            self.path: str = None
+            self.duration: float = 0.0
+            self.size: int = 0
+            self.first_added: datetime.datetime = None
+            self.last_mod: datetime.datetime = None
+            self.last_checked: datetime.datetime = None
+            self.last_upates: datetime.datetime = None
+            self.meta = ""
+        else:
+            self.from_db_row(db_row)
+
+    def __str__(self):
+        return f"Path:{self.path}, Dur:{self.duration}, Sz:{self.size}, Mod:{self.last_mod}"
+
+    def __eq__(self, value):
+        return self.to_stat_check() == value.to_stat_check()
+
+    def from_db_row(self, row):
+        (
+            self.path,
+            self.duration,
+            self.size,
+            self.first_added,
+            self.last_mod,
+            self.last_checked,
+            self.last_upates,
+            self.meta,
+        ) = row
+
+    def to_db_row(self):
+        return (
+            self.path,
+            self.duration,
+            self.size,
+            self.first_added,
+            self.last_mod,
+            self.last_checked,
+            self.last_upates,
+            self.meta,
+        )
+
+    def to_stat_check(self):
+        return (self.path, self.size, self.last_mod)

--- a/fs42/fluid_statements.py
+++ b/fs42/fluid_statements.py
@@ -1,0 +1,129 @@
+import logging
+import sqlite3
+import datetime
+import os
+from fs42.media_processor import MediaProcessor
+from fs42.fluid_objects import FileRepoEntry
+
+
+class FluidStatements:
+    """Basic static SQL functions for interacting with the Fluid catalog DB"""
+
+    @staticmethod
+    def check_file_cache(connection: sqlite3.Connection, full_path) -> FileRepoEntry:
+        """Find full_path and return fullpath if its in the file cache"""
+
+        cursor = connection.cursor()
+        cursor.execute("SELECT * FROM file_meta WHERE path = ?;", (full_path,))
+        row = cursor.fetchone()
+        result = None
+        if row:
+            repo_entry = FileRepoEntry(row)
+            result = repo_entry
+        cursor.close()
+        return result
+
+    @staticmethod
+    def iterate_file_entries(connection: sqlite3.Connection, entries: list[FileRepoEntry]) -> None:
+        """Takes a list of file entries, determines if they are cached and adds them if not."""
+
+        cursor = connection.cursor()
+        for entry in entries:
+            # see if there is an entry already
+            cursor.execute("SELECT * FROM file_meta WHERE path = ?;", (entry.path,))
+            row = cursor.fetchone()
+            if row:
+                repo_entry = FileRepoEntry()
+                repo_entry.from_db_row(row)
+
+                # compare it to the stats in the repo
+                if entry != repo_entry:
+                    # then the stats match
+                    FluidStatements.update_file_entry(connection, entry)
+
+            else:
+                FluidStatements.add_file_entry(connection, entry)
+        cursor.close()
+
+    @staticmethod
+    def trim_file_entries(connection: sqlite3.Connection):
+        """Checks all files in the cache to ensure still on disk and removes them if not."""
+
+        cursor = connection.cursor()
+        cursor.execute("SELECT * FROM file_meta;")
+        to_remove = []
+        rows = cursor.fetchall()
+        for row in rows:
+            repo_entry = FileRepoEntry()
+            repo_entry.from_db_row(row)
+            if not os.path.exists(repo_entry.path):
+                logging.getLogger("FLUID").info(f"File not found on filesystem - will remove: {repo_entry}")
+                to_remove.append(repo_entry.path)
+
+        connection.execute("BEGIN TRANSACTION;")
+
+        for p in to_remove:
+            cursor.execute("DELETE from file_meta WHERE path=?", (p,))
+
+        cursor.close()
+        connection.commit()
+
+    @staticmethod
+    def update_file_entry(connection: sqlite3.Connection, entry: FileRepoEntry):
+        """An old entry has changed, get the new stats and update it."""
+        cursor = connection.cursor()
+        now = datetime.datetime.now()
+
+        processed = MediaProcessor.process_one(entry.path, "processing", [])
+        if not processed:
+            return False
+        entry.duration = processed.duration
+
+        logging.getLogger("FLUID").info(f"Updating existing file entry: {entry.path}")
+
+        update = """UPDATE file_meta SET duration=?, size=?, last_mod=?, last_updated=?, last_checked=? 
+        WHERE path=?;
+        """
+        values = (entry.duration, entry.size, entry.last_mod, now, now, entry.path)
+        cursor.execute(update, values)
+        cursor.close()
+        connection.commit()
+
+    @staticmethod
+    def add_file_entry(connection: sqlite3.Connection, entry: FileRepoEntry):
+        """This file isn't in the cache - add it."""
+        cursor = connection.cursor()
+        now = datetime.datetime.now()
+
+        entry.first_added = now
+        entry.last_checked = now
+        entry.last_upates = now
+
+        processed = MediaProcessor.process_one(entry.path, "processing", [])
+        if not processed:
+            return False
+
+        entry.duration = processed.duration
+
+        logging.getLogger("FLUID").info(f"Caching new file entry: {entry}")
+
+        cursor.execute("INSERT INTO file_meta VALUES (?, ?, ?, ?, ?, ?, ?, ?);", entry.to_db_row())
+        cursor.close()
+        connection.commit()
+
+    @staticmethod
+    def init_db(connection: sqlite3.Connection):
+        cursor = connection.cursor()
+        cursor.execute("""CREATE TABLE IF NOT EXISTS file_meta ( 
+                            path TEXT PRIMARY KEY,
+                            duration REAL,
+                            size INTEGER,
+                            first_added TIMESTAMP,
+                            last_mod TIMESTAMP,
+                            last_checked TIMESTAMP,
+                            last_updated TIMESTAMP,
+                            meta TEXT
+                            )
+                            """)
+        
+        cursor.close()

--- a/fs42/fluid_statements.py
+++ b/fs42/fluid_statements.py
@@ -46,13 +46,14 @@ class FluidStatements:
         cursor.close()
 
     @staticmethod
-    def trim_file_entries(connection: sqlite3.Connection):
+    def trim_file_entries(connection: sqlite3.Connection, older_than:datetime):
         """Checks all files in the cache to ensure still on disk and removes them if not."""
 
         cursor = connection.cursor()
-        cursor.execute("SELECT * FROM file_meta;")
+        cursor.execute("SELECT * FROM file_meta WHERE last_updated < ?;", (older_than,))
         to_remove = []
         rows = cursor.fetchall()
+        logging.getLogger("FLUID").info(f"Checking {len(rows)} files on the filesystem")
         for row in rows:
             repo_entry = FileRepoEntry()
             repo_entry.from_db_row(row)
@@ -125,5 +126,5 @@ class FluidStatements:
                             meta TEXT
                             )
                             """)
-        
+
         cursor.close()

--- a/fs42/media_processor.py
+++ b/fs42/media_processor.py
@@ -2,7 +2,7 @@ import logging
 import os
 import glob
 import ffmpeg
-
+from fs42.fluid_objects import FileRepoEntry
 
 try:
     # try to import from version > 2.0
@@ -14,14 +14,50 @@ except ImportError:
 from fs42.schedule_hint import MonthHint, QuarterHint, RangeHint, BumpHint, DayPartHint
 from fs42.catalog_entry import CatalogEntry
 
-USE_EXPERIMENTAL_PROCESS = True
-
 
 class MediaProcessor:
     supported_formats = ["mp4", "mpg", "mpeg", "avi", "mov", "mkv"]
 
+    def process_one(fname, tag, hints, fluid=None) -> CatalogEntry:
+        _l = logging.getLogger("MEDIA")
+        _l.debug(f"--process_one is working on {fname}")
+        # get video file length in seconds
+        duration = 0.0
+        result = None
+        try:
+            if fluid:
+                full_path = os.path.realpath(fname)
+                cached = fluid.check_file_cache(full_path)
+                if cached:
+                    _l.info(f"Found cache version of {fname}")
+                    duration = cached.duration
+
+            if not duration:
+                # then do the processing
+                duration = MediaProcessor._get_duration(fname)
+
+            # it might not support streams, so check with moviepy
+            if duration <= 0.0:
+                video_clip = VideoFileClip(fname)
+                duration = video_clip.duration
+
+            # see if both returned 0
+            if duration <= 0.0:
+                _l.warning(f"Could not get a duration for tag: {tag}  file: {fname}")
+                _l.warning("Files with 0 length can't be added to the catalog.")
+            else:
+                show_clip = CatalogEntry(fname, duration, tag, hints)
+                result = show_clip
+                _l.debug(f"--_process_media is done with {fname}: {show_clip}")
+
+        except Exception as e:
+            _l.exception(e)
+            _l.error(f"Error processing media file {fname}")
+
+        return result
+
     @staticmethod
-    def _process_media(file_list, tag, hints=[]):
+    def _process_media(file_list, tag, hints=[], fluid=None) -> list[CatalogEntry]:
         _l = logging.getLogger("MEDIA")
         _l.debug(f"_process_media starting processing for tag={tag} on {len(file_list)} files")
         show_clip_list = []
@@ -33,31 +69,11 @@ class MediaProcessor:
         for fname in file_list:
             _l.debug(f"--_process_media is working on {fname}")
             # get video file length in seconds
-            duration = 0.0
-            try:
-                if USE_EXPERIMENTAL_PROCESS:
-                    # this wont work for mkv and webp and doesnt really save time - shouldn't use unless required
-                    duration = MediaProcessor._get_duration(fname)
-
-                # it might not support streams, so check with moviepy
-                if duration <= 0.0:
-                    video_clip = VideoFileClip(fname)
-                    duration = video_clip.duration
-
-                # see if both returned 0
-                if duration <= 0.0:
-                    _l.warning(f"Could not get a duration for tag: {tag}  file: {fname}")
-                    _l.warning("Files with 0 length can't be added to the catalog.")
-                    failed.append(fname)
-                else:
-                    show_clip = CatalogEntry(fname, duration, tag, hints)
-                    show_clip_list.append(show_clip)
-                    _l.debug(f"--_process_media is done with {fname}: {show_clip}")
-
-            except Exception as e:
-                _l.exception(e)
-                _l.error(f"Error processing media file {fname}")
-                failed.append(fname)
+            results = MediaProcessor.process_one(fname, tag, hints, fluid)
+            if results:
+                show_clip_list.append(results)
+            else:
+                failed.append(failed)
 
         _l.debug(f"_process_media completed processing for tag={tag} on {len(file_list)} files")
 
@@ -73,7 +89,7 @@ class MediaProcessor:
         return show_clip_list
 
     @staticmethod
-    def _get_duration(file_name):
+    def _get_duration(file_name) -> float:
         probed = ffmpeg.probe(file_name)
 
         if "streams" in probed and len(probed["streams"]) and "duration" in probed["streams"][0]:
@@ -82,7 +98,7 @@ class MediaProcessor:
             return -1
 
     @staticmethod
-    def _find_media(path):
+    def _find_media(path) -> list[str]:
         logging.getLogger("MEDIA").debug(f"_find_media scanning for media in {path}")
         file_list = []
         for ext in MediaProcessor.supported_formats:
@@ -96,7 +112,22 @@ class MediaProcessor:
         return file_list
 
     @staticmethod
-    def _rfind_media(path):
+    def rich_find_media(path: str) -> list[FileRepoEntry]:
+        file_list = MediaProcessor._rfind_media(path)
+        found_list = []
+
+        for fp in file_list:
+            entry = FileRepoEntry()
+            entry.path = os.path.realpath(fp)
+            # get the full path:
+            stat = os.stat(fp)
+            entry.last_mod = stat.st_mtime
+            entry.size = stat.st_size
+            found_list.append(entry)
+        return found_list
+
+    @staticmethod
+    def _rfind_media(path) -> list[str]:
         logging.getLogger("MEDIA").debug(f"_rfind_media scanning for media in {path}")
         file_list = []
 

--- a/fs42/media_processor.py
+++ b/fs42/media_processor.py
@@ -29,7 +29,7 @@ class MediaProcessor:
                 full_path = os.path.realpath(fname)
                 cached = fluid.check_file_cache(full_path)
                 if cached:
-                    _l.info(f"Found cache version of {fname}")
+                    _l.info(f"Using cache version of {fname}")
                     duration = cached.duration
 
             if not duration:
@@ -159,13 +159,13 @@ class MediaProcessor:
         return hints
 
     @staticmethod
-    def _process_subs(dir_path, tag, bumpdir=False):
+    def _process_subs(dir_path, tag, bumpdir=False, fluid=None):
         subs = [f.path for f in os.scandir(dir_path) if f.is_dir()]
         clips = []
         for sub in subs:
             file_list = MediaProcessor._rfind_media(sub)
             hints = MediaProcessor._process_hints(sub, tag, bumpdir)
-            clips += MediaProcessor._process_media(file_list, tag, hints=hints)
+            clips += MediaProcessor._process_media(file_list, tag, hints=hints, fluid=fluid)
         return clips
 
     @staticmethod

--- a/station_42.py
+++ b/station_42.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import argparse
-
+import datetime
 from fs42.catalog import ShowCatalog
 from fs42.station_manager import StationManager
 from fs42.liquid_manager import LiquidManager
@@ -23,6 +23,8 @@ class Station42:
         self.check_catalog = self.catalog.check_catalog
 
 def main():
+
+    execution_start_time = datetime.datetime.now()
 
     parser = argparse.ArgumentParser(description='FieldStation42 Catalog and Liquid-Schedule Generation')
     parser.add_argument('-g', '--graphical_interface', action='store_true', help='Run graphical interface to configure catalogs and schedules')
@@ -150,7 +152,7 @@ def main():
 
     
     if args.rebuild_catalog and FF_USE_FLUID_FILE_CACHE:
-        FluidBuilder().trim_file_cache()
+        FluidBuilder().trim_file_cache(execution_start_time)
 
 
     if args.printcat and not found_print_target:

--- a/station_42.py
+++ b/station_42.py
@@ -1,12 +1,14 @@
 import logging
 import sys
+import argparse
 
 from fs42.catalog import ShowCatalog
 from fs42.station_manager import StationManager
 from fs42.liquid_manager import LiquidManager
 from fs42.liquid_schedule import LiquidSchedule
+from fs42.fluid_builder import FluidBuilder
 
-import argparse
+FF_USE_FLUID_FILE_CACHE = True
 
 logging.basicConfig(format='%(levelname)s:%(name)s:%(message)s', level=logging.INFO)
 
@@ -146,8 +148,15 @@ def main():
                 else:
                     logging.getLogger().info("No schedules generated, use -h --help to see available options")
 
+    
+    if args.rebuild_catalog and FF_USE_FLUID_FILE_CACHE:
+        FluidBuilder().trim_file_cache()
+
+
     if args.printcat and not found_print_target:
         logging.getLogger().error(f"Could not find catalog for network named: {args.printcat}")
+
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Overview
Introduces file caching for catalog builds.

### Improvements:
- File-meta caching implemented - `content_dir` is now indexed at the start of each run
- When building catalogs, each file is checked against the file cache for `sameness` based on dereferenced path, size and mod-time - if found then calculations on the file are not repeated
- If something has changed, only those files are fully processed

### Now:
- Big time-savings when adding time to existing catalogs since it will now only do full processing on change files and it checks - files that have not been updated recently to ensure they are still on disk
- Big time-saving if you are using shared content, since it uses dereferenced paths (full, real path on disk) it will only read it once. If your channels share a common pool of commercials by symlinks, then you will note that this runs through your channels much faster.
- Its very chatty right now - will work on getting the right level of feedback.

This is behind a feature flag of sorts, though I will commit with it turned on. The backing data store for the new file meta cache is using sqlite3.