### PR TITLE
Commercial break point detection

### DIFF
--- a/find_breaks.py
+++ b/find_breaks.py
@@ -1,0 +1,101 @@
+# Tries to finds appropriate commercial break points in videos using either existing chapter marks or ffmpeg's blackdetect filter.
+
+import os, sys, re, json
+import ffmpeg
+import argparse
+import tempfile
+
+from fs42.media_processor import MediaProcessor
+
+def strat_chapters(filepath, args):
+    break_points = []
+    probe_out = ffmpeg.probe(filepath, show_chapters=None)
+    for chapter in probe_out["chapters"]:
+        break_points.append(float(chapter["start_time"]))
+    return break_points
+
+def strat_blackdetect(filepath, duration, args, min_duration=0.5, black_level=0.1, black_amount=0.999):
+    _, err = (
+        ffmpeg
+        .input(filepath, ss=args.ignore_start, to=(duration - args.ignore_end))
+        .filter('blackdetect', d=min_duration, pix_th=black_level, pic_th=black_amount)
+        .output('-', format='null')
+        .global_args('-copyts', '-hide_banner', '-nostats')
+        .run(capture_stdout=False, capture_stderr=True)
+    )
+
+    # Example blackdetect line:
+    # [blackdetect @ 0x5567b5806dc0] black_start:300.467 black_end:302.844 black_duration:2.377
+    break_points = re.findall(r'\n\[blackdetect.+black_start:([^ ]+) black_end:([^ ]+)',err.decode('utf-8'))
+
+    # Reduce from (start, end) tuple to just the mid point
+    break_points = [(float(x[0]) + float(x[1]))*0.5 for x in break_points]
+
+    return break_points
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('files', type=str, nargs='*')
+    parser.add_argument('--db', dest='dbpath', action='store', type=str, required=True, help='The json file the results will be stored in.')
+    parser.add_argument('--ignore_start', dest='ignore_start', action='store', type=float, default=120.0, help='Ignore any break found before this time (in seconds).')
+    parser.add_argument('--ignore_end', dest='ignore_end', action='store', type=float, default=180.0, help='Ignore any break found after this time from the end (in seconds).')
+    parser.add_argument('--min_segment_time', dest='min_segment_time', action='store', type=float, default=120.0, help='Minimum time between breaks (in seconds).')
+    parser.add_argument('--strategy', dest='strategy', choices=['auto', 'chapter', 'blackdetect'], default='auto', help='Strategy used to detect break points. Note: blackdetect needs to scan each frame of the video and can be quite slow.')
+    parser.add_argument('-f', '--force', dest='force', action='store_true', help='Repeat operation even if already in the database.')
+
+    args = parser.parse_args()
+
+    if os.path.exists(args.dbpath):
+        with open(args.dbpath, "r") as f:
+            db = json.load(f)
+    else:
+        db = {}
+
+    for filepath in args.files:
+        if not args.force and filepath in db:
+            print(f"Skipping {filepath}")
+            continue
+
+        duration = MediaProcessor._get_duration(filepath)
+        if duration <= 0:
+            print(f"Failed to determine duration '{filepath}'")
+            continue
+
+        if args.strategy == 'chapter' or args.strategy == 'auto':
+            break_points = strat_chapters(filepath, args)
+        if args.strategy == 'blackdetect' or (args.strategy == 'auto' and len(break_points) == 0):
+            break_points = strat_blackdetect(filepath, duration, args)
+
+        if not break_points or len(break_points) == 0:
+            print(f"No break points found for '{filepath}'")
+            continue
+
+        # Filter entries in the ignore periods
+        break_points = [x for x in break_points if x >= args.ignore_start and x < (duration - args.ignore_end)]
+
+        # Filter entries that don't meet the minimum segment time
+        if len(break_points) > 0:
+            prior = break_points[0]
+            filtered = [prior]
+            for bp in break_points[1:]:
+                if bp - prior < args.min_segment_time:
+                    continue
+                filtered.append(bp)
+                prior = bp
+            break_points = filtered
+
+        if len(break_points) == 0:
+            print(f"No valid break points found for '{filepath}'")
+            continue
+
+        # Add end of video break
+        break_points.append(duration)
+
+        db[filepath] = break_points
+        print(f'"{filepath}": {str(break_points)}')
+
+    tempf, tempfname = tempfile.mkstemp()
+    json.dump(db, os.fdopen(tempf, "w"))
+    os.replace(tempfname, args.dbpath)
+

--- a/fs42/liquid_blocks.py
+++ b/fs42/liquid_blocks.py
@@ -5,7 +5,7 @@ from fs42.block_plan import BlockPlanEntry
 
 
 class LiquidBlock:
-    def __init__(self, content, start_time, end_time, title=None, break_strategy="standard", break_info=None):
+    def __init__(self, content, start_time, end_time, title=None, break_strategy="standard", break_info=None, break_points=None):
         self.content = content
         # the requested starting time
         self.start_time = start_time
@@ -26,6 +26,8 @@ class LiquidBlock:
             self.end_bump = break_info["end_bump"] if "end_bump" in break_info else None
             self.bump_override = break_info["bump_dir"] if "bump_dir" in break_info else None
             self.commercial_override = break_info["commercial_dir"] if "commercial_dir" in break_info else None
+
+        self.break_points = break_points
 
     def __str__(self):
         return f"{self.start_time.strftime('%m/%d %H:%M')} - {self.end_time.strftime('%H:%M')} - {self.title}"
@@ -58,7 +60,7 @@ class LiquidBlock:
 
         if diff > 2:
             self.reel_blocks = catalog.make_reel_fill(
-                self.start_time, diff, commercial_dir=self.commercial_override, bump_dir=self.bump_override
+                self.start_time, diff, commercial_dir=self.commercial_override, bump_dir=self.bump_override, break_points=self.break_points
             )
         else:
             self.reel_blocks = []
@@ -71,6 +73,7 @@ class LiquidBlock:
             self.break_strategy,
             self.start_bump,
             self.end_bump,
+            self.break_points,
         )
 
 

--- a/fs42/media_processor.py
+++ b/fs42/media_processor.py
@@ -93,7 +93,14 @@ class MediaProcessor:
 
     @staticmethod
     def _get_duration(file_name) -> float:
-        probed = ffmpeg.probe(file_name)
+        probed = ffmpeg.probe(file_name, show_entries='stream', select_streams='v:0')
+        try:
+            # Some MKV files do not have stream duration, but include it in a language tag.
+            h,m,s = (probed['streams'][0]['tags']['DURATION-eng']).split(':')
+            duration = float(h) * 3600.0 + float(m) * 60.0 + float(s)
+            return duration
+        except:
+            pass
 
         if "streams" in probed and len(probed["streams"]) and "duration" in probed["streams"][0]:
             return float(probed["streams"][0]["duration"])

--- a/fs42/reel_cutter.py
+++ b/fs42/reel_cutter.py
@@ -3,7 +3,7 @@ from fs42.block_plan import BlockPlanEntry
 
 class ReelCutter:
     @staticmethod
-    def cut_reels_into_base(base_clip, reel_blocks, base_offset, base_duration, break_stratgy, start_bump, end_bump):
+    def cut_reels_into_base(base_clip, reel_blocks, base_offset, base_duration, break_stratgy, start_bump, end_bump, break_points):
         entries = []
         break_count = 0
 
@@ -12,6 +12,8 @@ class ReelCutter:
 
         if reel_blocks:
             break_count = len(reel_blocks)
+
+        assert not break_points or len(break_points) == break_count
 
         if break_count <= 1 or break_stratgy == "end":
             # then don't cut the base at all
@@ -24,6 +26,8 @@ class ReelCutter:
             offset = base_offset
 
             for i in range(break_count):
+                if break_points:
+                    segment_duration = break_points[i] - break_points[i-1] if i > 0 else break_points[i]
                 entries.append(BlockPlanEntry(base_clip.path, offset, segment_duration))
                 entries += reel_blocks[i].make_plan()
                 offset += segment_duration


### PR DESCRIPTION
- Changes the scheduler to allow setting specific break points for commercials
- Changes the reel scheduler algorithm so that it produces a fixed amount of breaks
- Adds a station config value for specifying a json database with those break points defined.
- Small tool to generate break points based on either pre-existing chapters extracted from the video file metadata, or by using ffmpeg's blackdetect filter to find fades to black.
