### PR TITLE
Adding memory limiter to CLI tool

### DIFF
--- a/station_42.py
+++ b/station_42.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import resource
 import argparse
 import datetime
 from rich.console import Console
@@ -149,6 +150,14 @@ def build_parser():
         action="store_true",
         help="Run the FieldStation42 web API server after other actions.",
     )
+
+    parser.add_argument(
+        "--limit_memory",
+        nargs=1,
+        type=float,
+        help="Enter a number 0.1 and 1.0 to limit the memory usage of a command."
+    )
+
     return parser
 
 
@@ -212,6 +221,22 @@ def main():
                         f"Failed to rebuild catalog for {station['network_name']} - check logs."
                     )
 
+    def get_memory():
+        with open('/proc/meminfo', 'r') as mem:
+            free_memory = 0
+            for i in mem:
+                sline = i.split()
+                if str(sline[0]) in ('MemFree:', 'Buffers:', 'Cached:'):
+                    free_memory += int(sline[1])
+        return free_memory  # KiB
+
+
+    def memory_limit(percent):
+        """Limit max memory usage to half."""
+        soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+        # Convert KiB to bytes, and divide in two to half
+        resource.setrlimit(resource.RLIMIT_AS, (int(get_memory() * 1024 / (1/percent)), hard))
+        _l.info("Reducing available memory usage.")
 
     execution_start_time = datetime.datetime.now()
     parser = build_parser()
@@ -240,6 +265,16 @@ def main():
         fh.setFormatter(formatter)
         _l.addHandler(fh)
         success_messages.append(f"I setup logging to file: {args.logfile}")
+
+    if args.limit_memory:
+        memory_percent = args.limit_memory[0]
+        if memory_percent > 1:
+            memory_percent = 1
+            _l.info("Memory percent too high. Using full memory.")
+        elif memory_percent < 0.1:
+            memory_percent = 0.1
+            _l.info("Memory percent too low. Setting to 10%.")
+        memory_limit(memory_percent)
 
     if args.schedule:
         _l.info("Printing shedule summary.")


### PR DESCRIPTION
Usage: --limit-memory requires a float if declared. Will not allow under 10% of memory limit.