### PR TITLE
Use ffmpeg probe for duration

### DIFF
--- a/fs42/media_processor.py
+++ b/fs42/media_processor.py
@@ -60,7 +60,7 @@ class MediaProcessor:
             _l.error(f"Error processing media file {fname}")
 
         return result
-            
+
     @staticmethod
     def _process_media(file_list, tag, hints=[], fluid=None) -> list[CatalogEntry]:
         _l = logging.getLogger("MEDIA")


### PR DESCRIPTION
With some of my video files i have several audio and or video streams, these caused issues with moviepy not allowing it to get duration and not being able to be added to the catalog. Switching to ffmpeg probe it is able to find duration in those with and without multi streams.