### PR TITLE
Add temporal and tag-aware station logo selection

### DIFF
--- a/fs42/osd/logo_display.py
+++ b/fs42/osd/logo_display.py
@@ -1,11 +1,13 @@
 import json
 import sys
 from pathlib import Path
+import datetime
+import random
+import glob
+
 import glfw
 from pydantic import BaseModel
 from enum import Enum
-import random
-import glob
 
 from render import load_texture
 from OpenGL.GL import *
@@ -14,34 +16,38 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from fs42.station_manager import StationManager
-from fs42.osd.content_classifier import ContentClassifier, ContentType, classify_current_content # ContentClassifier unused
+from fs42.osd.content_classifier import ContentType, classify_current_content
 
 SOCKET_FILE = "runtime/play_status.socket"
+
 
 class HAlignment(Enum):
     LEFT = "LEFT"
     RIGHT = "RIGHT"
     CENTER = "CENTER"
 
+
 class VAlignment(Enum):
     TOP = "TOP"
     BOTTOM = "BOTTOM"
     CENTER = "CENTER"
 
+
 class LogoDisplayConfig(BaseModel):
     halign: HAlignment = HAlignment.RIGHT
     valign: VAlignment = VAlignment.TOP
-    width: float = 0.112  
-    height: float = 0.15  
+    width: float = 0.112
+    height: float = 0.15
     x_margin: float = 0.05
     y_margin: float = 0.05
     logo_mapping: dict[str, str] = {}
     default_logo: str | None = None
     always_show: bool = False
     display_time: float = 5.0
-    default_show_logo: bool = True 
+    default_show_logo: bool = True
     default_logo_permanent: bool = False
     default_logo_alpha: float = 1.0
+
 
 class LogoDisplay(object):
     def __init__(self, window, config: LogoDisplayConfig):
@@ -49,145 +55,450 @@ class LogoDisplay(object):
         self.window = window
         self.window_width, self.window_height = glfw.get_framebuffer_size(window)
         self.station_manager = StationManager()
-        self.current_logo_textures = []  # List of textures for animated GIFs
-        self.current_logo_size = (0, 0)
-        self.current_frame_durations = []  # Duration for each frame in seconds
-        self.current_frame_index = 0
-        self.frame_timer = 0.0
-        self.is_animated = False
-        self.current_channel_info = {}
-        self.channel_config = {}  # stores per-channel config like show_logo, logo_permanent
-        self.time_since_change = float('inf')
-        self.current_content_type = ContentType.UNKNOWN
-        self.available_logos = [] 
-        self.current_logo_path = None
-        self.is_displaying_osd_default_logo = False 
+
+        self.current_logo_textures: list[int] = []
+        self.current_logo_size: tuple[int, int] = (0, 0)
+        self.current_frame_durations: list[float] = []
+        self.current_frame_index: int = 0
+        self.frame_timer: float = 0.0
+        self.is_animated: bool = False
+
+        self.current_channel_info: dict = {}
+        self.channel_config: dict = {}
+        self.time_since_change: float = float("inf")
+        self.current_content_type: ContentType = ContentType.UNKNOWN
+        self.available_logos: list[Path] = []
+        self.current_logo_path: str | None = None
+        self.is_displaying_osd_default_logo: bool = False
+
+        self.main_config: dict | None = None
+
         self.check_status()
 
-    def get_available_logos(self, logo_dir_path):
-        """Get list of all logo files in the logo directory"""
-        logo_extensions = ['*.png', '*.jpg', '*.jpeg', '*.gif', '*.bmp']
-        available_logos = []
-        
-        for ext in logo_extensions:
-            available_logos.extend(glob.glob(str(logo_dir_path / ext)))
-            available_logos.extend(glob.glob(str(logo_dir_path / ext.upper())))
-        
-        return [Path(logo) for logo in available_logos]
+    # -------------------------------------------------------------------------
+    # Helpers to load logos and config
+    # -------------------------------------------------------------------------
 
-    def select_logo_for_channel(self, station_data):
-        """Select which logo to use based on multi_logo setting"""
-        multi_logo_setting = station_data.get("multi_logo", "single").lower()
+    def get_available_logos(self, dir_path: Path) -> list[Path]:
+        extensions = ["*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp"]
+        found: list[str] = []
+        for ext in extensions:
+            found.extend(glob.glob(str(dir_path / ext)))
+            found.extend(glob.glob(str(dir_path / ext.upper())))
+        return [Path(p) for p in found]
 
-        if multi_logo_setting == "off":
-            multi_logo_setting = "single"
-        elif multi_logo_setting == "random":
-            multi_logo_setting = "multi"
+    def load_main_config(self) -> dict:
+        """
+        Load main_config.json from confs/, where FS42 keeps all config files.
+        """
+        if self.main_config is not None:
+            return self.main_config
 
-        if multi_logo_setting not in ["single", "multi"]:
-            multi_logo_setting = "single"  # Default fallback
-        
+        cfg_path = project_root / "confs" / "main_config.json"
+
+        try:
+            with open(cfg_path, "r") as f:
+                self.main_config = json.load(f)
+        except Exception:
+            self.main_config = {}
+
+        return self.main_config
+
+
+    # -------------------------------------------------------------------------
+    # Tag-based content directory: logo_dir/<first_tag>/
+    #    - tags derived from the station's schedule (day/hour-based)
+    # -------------------------------------------------------------------------
+
+    def find_content_logo_dir(self, base_dir: Path, station_data: dict) -> Path | None:
+        """
+        Use the station's schedule to determine the active tag, and
+        map that tag to a subdirectory under base_dir.
+        """
+        now = datetime.datetime.now()
+        day_key = now.strftime("%A").lower()  # "monday", "tuesday", etc.
+        day_schedule = station_data.get(day_key)
+
+        if not isinstance(day_schedule, dict):
+            return None
+
+        # Try exact hour match first
+        hour_str = str(now.hour)
+        slot = day_schedule.get(hour_str)
+
+        # Optional fallback: latest hour <= now.hour
+        if slot is None:
+            try:
+                sorted_hours = sorted(
+                    (int(h) for h in day_schedule.keys() if h.isdigit())
+                )
+                eligible = [h for h in sorted_hours if h <= now.hour]
+                if eligible:
+                    best_hour = str(eligible[-1])
+                    slot = day_schedule.get(best_hour)
+            except Exception:
+                slot = None
+
+        if not isinstance(slot, dict):
+            return None
+
+        val = slot.get("tags") or slot.get("tag")
+        if not val:
+            return None
+
+        # Support either a single string or a list/tuple of tags
+        if isinstance(val, str):
+            first_tag = val
+        elif isinstance(val, (list, tuple)) and val:
+            first_tag = str(val[0])
+        else:
+            return None
+
+        safe = (
+            first_tag.strip()
+            .replace(" ", "_")
+            .replace("/", "_")
+            .replace("\\", "_")
+            .replace(":", "_")
+        )
+        candidate = base_dir / safe
+        if candidate.exists() and candidate.is_dir():
+            return candidate
+        return None
+
+    # -------------------------------------------------------------------------
+    # Month-based temporal directory: logo_dir/<Month>/ or ranges
+    # -------------------------------------------------------------------------
+
+    def find_temporal_logo_dir(self, base_dir: Path) -> Path | None:
+        today = datetime.date.today()
+        month_name = today.strftime("%B")
+        day = today.day
+
+        if not base_dir.exists():
+            return None
+
+        for sub in base_dir.iterdir():
+            if not sub.is_dir():
+                continue
+
+            name = sub.name
+
+            # Exact month match, e.g. "October"
+            if name == month_name:
+                return sub
+
+            # Month range: "October 1 - October 31"
+            parts = name.split(" - ")
+            if len(parts) == 2:
+                left, right = parts
+                lp = left.split()
+                rp = right.split()
+                if len(lp) == 2 and len(rp) == 2:
+                    m1, d1s = lp
+                    m2, d2s = rp
+                    if m1 == m2 == month_name:
+                        try:
+                            d1 = int(d1s)
+                            d2 = int(d2s)
+                            if d1 <= day <= d2:
+                                return sub
+                        except ValueError:
+                            pass
+
+        return None
+
+    # -------------------------------------------------------------------------
+    # Day-part detection from main_config.json (start_hour / end_hour)
+    # -------------------------------------------------------------------------
+
+    def get_current_day_part(self) -> str | None:
+        """
+        Determine the current day_part from main_config.json.
+
+        Expected shape:
+
+            "day_parts": {
+                "morning":  { "start_hour": 6,  "end_hour": 10 },
+                "daytime":  { "start_hour": 10, "end_hour": 17 },
+                "prime":    { "start_hour": 17, "end_hour": 21 },
+                "late":     { "start_hour": 21, "end_hour": 2 },
+                "overnight":{ "start_hour": 2,  "end_hour": 6 }
+            }
+
+        Wrap-around parts (e.g. 21 → 2) are supported.
+        """
+        cfg = self.load_main_config()
+        day_parts = cfg.get("day_parts")
+        if not day_parts or not isinstance(day_parts, dict):
+            return None
+
+        now = datetime.datetime.now()
+        now_hour = now.hour
+
+        for name, spec in day_parts.items():
+            if not isinstance(spec, dict):
+                continue
+            start = spec.get("start_hour")
+            end = spec.get("end_hour")
+            if start is None or end is None:
+                continue
+
+            # Same-day range (e.g., 6 → 10)
+            if start <= end:
+                if start <= now_hour < end:
+                    return name
+            else:
+                # Wrap past midnight (e.g., 21 → 2)
+                if now_hour >= start or now_hour < end:
+                    return name
+
+        return None
+
+    # -------------------------------------------------------------------------
+    # Weekday helper: "Monday", "Tuesday", etc.
+    # -------------------------------------------------------------------------
+
+    def get_current_weekday(self) -> str:
+        """
+        Return current weekday name, e.g. "Friday".
+        """
+        today = datetime.date.today()
+        return today.strftime("%A")
+
+    # -------------------------------------------------------------------------
+    # Logo selection logic with full hierarchy
+    # -------------------------------------------------------------------------
+
+    def select_logo_for_channel(self, station_data: dict) -> Path | None:
+        """
+        Selection hierarchy:
+
+            1. Tag-based folder:           logo_dir/<first_tag>/
+            2. Month + Weekday + daypart:  logo_dir/<Month>/<Weekday>/<day_part>/
+            3. Month + Weekday:            logo_dir/<Month>/<Weekday>/
+            4. Month + daypart:            logo_dir/<Month>/<day_part>/
+            5. Month-only:                 logo_dir/<Month>/ or month-range
+            6. Weekday + daypart:          logo_dir/<Weekday>/<day_part>/
+            7. Weekday-only:               logo_dir/<Weekday>/
+            8. daypart-only:               logo_dir/<day_part>/
+            9. Base directory              (original FS42 behavior)
+        """
+        multi = station_data.get("multi_logo", "single").lower()
+        if multi == "off":
+            multi = "single"
+        elif multi == "random":
+            multi = "multi"
+        if multi not in ("single", "multi"):
+            multi = "single"
+
         content_dir = station_data.get("content_dir")
         logo_dir = station_data.get("logo_dir")
         default_logo_name = station_data.get("default_logo")
 
+        # Original FS42 semantics: logo_dir relative to content_dir if present,
+        # otherwise relative to project_root.
         if content_dir and logo_dir:
-            logo_dir_path = Path(content_dir) / logo_dir
-        elif logo_dir: 
-            logo_dir_path = project_root / logo_dir
+            base_dir = Path(content_dir) / logo_dir
+        elif logo_dir:
+            base_dir = project_root / logo_dir
         else:
             return None
-        
-        if multi_logo_setting == "single":
-            if default_logo_name:
-                return logo_dir_path / default_logo_name
-        else: 
-            if not hasattr(self, 'available_logos') or not self.available_logos:
-                self.available_logos = self.get_available_logos(logo_dir_path)
-            
-            if self.available_logos:
-                selected_logo = random.choice(self.available_logos)
-                return selected_logo
-        
-        return None
 
-    def check_status(self, socket_file=SOCKET_FILE):
+        override_dirs: list[Path] = []
+
+        # 1) Content tag override (derived from the station's schedule)
+        cdir = self.find_content_logo_dir(base_dir, station_data)
+        if cdir:
+            override_dirs.append(cdir)
+
+        # Temporal hints: month, weekday, day_part
+        month_dir = self.find_temporal_logo_dir(base_dir)
+        day_part_name = self.get_current_day_part()
+        weekday_name = self.get_current_weekday()
+
+        # Normalize day_part to filesystem-friendly name
+        day_part_folder = None
+        if day_part_name:
+            day_part_folder = day_part_name.replace(" ", "_")
+
+        # Helper to add a candidate directory if it exists and isn't already listed
+        def add_candidate(path: Path):
+            if path and path.exists() and path.is_dir():
+                if path not in override_dirs:
+                    override_dirs.append(path)
+
+        # 2) Month-based combinations first (most specific → less specific)
+        if month_dir:
+            # Month / Weekday / day_part
+            if weekday_name and day_part_folder:
+                add_candidate(month_dir / weekday_name / day_part_folder)
+
+            # Month / Weekday
+            if weekday_name:
+                add_candidate(month_dir / weekday_name)
+
+            # Month / day_part
+            if day_part_folder:
+                add_candidate(month_dir / day_part_folder)
+
+            # Month-only
+            add_candidate(month_dir)
+        else:
+            # 3) Only use generic weekday/day_part when month_dir is not present
+            # Weekday / day_part
+            if weekday_name and day_part_folder:
+                add_candidate(base_dir / weekday_name / day_part_folder)
+
+            # Weekday-only
+            if weekday_name:
+                add_candidate(base_dir / weekday_name)
+
+            # day_part-only
+            if day_part_folder:
+                add_candidate(base_dir / day_part_folder)
+
+        def pick_single() -> Path | None:
+            # Try override dirs in order
+            for d in override_dirs:
+                logos = self.get_available_logos(d)
+                if logos:
+                    if default_logo_name:
+                        cand = d / default_logo_name
+                        if cand.exists():
+                            return cand
+                    return random.choice(logos)
+
+            # Fallback: default_logo in base_dir if defined
+            if default_logo_name:
+                cand = base_dir / default_logo_name
+                if cand.exists():
+                    return cand
+
+            # Fallback: any logo in base_dir
+            logos = self.get_available_logos(base_dir)
+            if logos:
+                return random.choice(logos)
+
+            return None
+
+        def pick_multi() -> Path | None:
+            pool: list[Path] = []
+            for d in override_dirs:
+                pool.extend(self.get_available_logos(d))
+            if pool:
+                self.available_logos = pool
+                return random.choice(pool)
+
+            logos = self.get_available_logos(base_dir)
+            if logos:
+                self.available_logos = logos
+                return random.choice(logos)
+
+            return None
+
+        return pick_single() if multi == "single" else pick_multi()
+
+    # -------------------------------------------------------------------------
+    # Status reading and content tracking
+    # -------------------------------------------------------------------------
+
+    def check_status(self, socket_file: str = SOCKET_FILE) -> None:
         try:
             with open(socket_file, "r") as f:
-                status = f.read()
-                status = json.loads(status)
+                status = json.loads(f.read())
 
-                current_network = self.current_channel_info.get("network_name")
-                current_title = self.current_channel_info.get("title")
-                new_network = status.get("network_name")
-                new_title = status.get("title")
-                
-                if new_network != current_network:
-                    self.current_channel_info = status
-                    self.time_since_change = 0
-                    self.available_logos = []
-                    self.load_logo_for_channel(status)
-                    # Update content type when title changes
-                    self.current_content_type = classify_current_content()
-                elif new_title != current_title:
-                    # Update content type when title changes
-                    old_content_type = self.current_content_type
-                    self.current_content_type = classify_current_content()
-                    # Reset timer when returning to FEATURE content
-                    if old_content_type != ContentType.FEATURE and self.current_content_type == ContentType.FEATURE:
-                        self.time_since_change = 0
-                        if self.channel_config.get("multi_logo", "single").lower() in ["multi", "random"]:
-                            self.load_logo_for_channel(status)
-                    self.current_channel_info = status
-                else:
-                    self.current_channel_info = status
-                    
+            curr_net = self.current_channel_info.get("network_name")
+            curr_title = self.current_channel_info.get("title")
+            new_net = status.get("network_name")
+            new_title = status.get("title")
+
+            if new_net != curr_net:
+                self.current_channel_info = status
+                self.time_since_change = 0.0
+                self.available_logos = []
+                self.load_logo_for_channel(status)
+                self.current_content_type = classify_current_content()
+
+            elif new_title != curr_title:
+                old_type = self.current_content_type
+                self.current_content_type = classify_current_content()
+                if (
+                    old_type != ContentType.FEATURE
+                    and self.current_content_type == ContentType.FEATURE
+                ):
+                    self.time_since_change = 0.0
+                    if self.channel_config.get("multi_logo", "single").lower() in (
+                        "multi",
+                        "random",
+                    ):
+                        self.load_logo_for_channel(status)
+                self.current_channel_info = status
+
+            else:
+                self.current_channel_info = status
+
         except Exception as e:
             print(f"Unable to parse player status for logo: {e}")
 
-    def load_animated_gif(self, gif_path):
-        """Load an animated GIF and extract all frames"""
+    # -------------------------------------------------------------------------
+    # Logo loading
+    # -------------------------------------------------------------------------
+
+    def load_animated_gif(self, path: str) -> bool:
         try:
             from PIL import Image
+
             self.clear_logo_textures()
-            with Image.open(gif_path) as img:
-                frames = []
-                durations = []
+            with Image.open(path) as img:
+                frames: list[int] = []
+                durations: list[float] = []
                 width, height = img.size
-                for frame_num in range(img.n_frames):
-                    img.seek(frame_num)
-                    frame = img.convert('RGBA')
-                    duration = img.info.get('duration', 100) / 1000.0
-                    durations.append(duration)
-                    frame_data = frame.tobytes()
-                    frame_width, frame_height = frame.size
-                    texture_id = glGenTextures(1)
-                    glBindTexture(GL_TEXTURE_2D, texture_id)
-                    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, frame_width, frame_height, 0, 
-                               GL_RGBA, GL_UNSIGNED_BYTE, frame_data)
+
+                for i in range(img.n_frames):
+                    img.seek(i)
+                    frame = img.convert("RGBA")
+                    duration = max(img.info.get("duration", 100) / 1000.0, 0.01)
+                    data = frame.tobytes()
+                    fw, fh = frame.size
+
+                    tex = glGenTextures(1)
+                    glBindTexture(GL_TEXTURE_2D, tex)
+                    glTexImage2D(
+                        GL_TEXTURE_2D,
+                        0,
+                        GL_RGBA,
+                        fw,
+                        fh,
+                        0,
+                        GL_RGBA,
+                        GL_UNSIGNED_BYTE,
+                        data,
+                    )
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
-                    frames.append(texture_id)
+
+                    frames.append(tex)
+                    durations.append(duration)
+
                 self.current_logo_textures = frames
                 self.current_frame_durations = durations
                 self.current_logo_size = (width, height)
                 self.current_frame_index = 0
                 self.frame_timer = 0.0
                 self.is_animated = len(frames) > 1
-                print(f"[INFO] Loaded animated GIF: {gif_path} ({len(frames)} frames)")
+
+                print(f"[INFO] Loaded animated logo: {path}")
                 return True
-        except ImportError:
-            print("[ERROR] PIL (Pillow) is required for animated GIF support. Install with: pip install Pillow")
-            return False
+
         except Exception as e:
-            print(f"[ERROR] Error loading animated GIF {gif_path}: {e}")
+            print(f"[ERROR] Error loading animated logo {path}: {e}")
             self.clear_logo_textures()
             return False
-    
-    def clear_logo_textures(self):
-        """Clear all current logo textures"""
+
+    def clear_logo_textures(self) -> None:
         if self.current_logo_textures:
             glDeleteTextures(self.current_logo_textures)
         self.current_logo_textures = []
@@ -196,186 +507,193 @@ class LogoDisplay(object):
         self.current_frame_index = 0
         self.frame_timer = 0.0
         self.is_animated = False
-        
-    def load_static_logo(self, logo_path):
-        """Load a static logo (PNG, JPG, etc.)"""
+
+    def load_static_logo(self, path: str) -> None:
         self.clear_logo_textures()
         try:
-            texture_id, width, height = load_texture(logo_path)
-            self.current_logo_textures = [texture_id]
-            self.current_frame_durations = [0]  # Static image has no duration
-            self.current_logo_size = (width, height)
+            tex, w, h = load_texture(path)
+            self.current_logo_textures = [tex]
+            self.current_frame_durations = [0.0]
+            self.current_logo_size = (w, h)
             self.current_frame_index = 0
             self.frame_timer = 0.0
             self.is_animated = False
-            print(f"[INFO] Loaded static logo: {logo_path}")
+            print(f"[INFO] Loaded static logo: {path}")
         except Exception as e:
-            print(f"[ERROR] Error loading static logo {logo_path}: {e}")
+            print(f"[ERROR] Error loading static logo {path}: {e}")
             self.clear_logo_textures()
 
-    def load_logo_for_channel(self, channel_info):
-        logo_path = None
+    def load_logo_for_channel(self, info: dict) -> None:
+        logo_path: Path | None = None
         self.channel_config = {}
-        self.is_displaying_osd_default_logo = False 
-        network_name = channel_info.get("network_name")
-        station_wants_to_show_logo = True
+        self.is_displaying_osd_default_logo = False
 
-        if network_name:
+        net = info.get("network_name")
+        show_logo = True
+
+        if net:
             try:
-                station_data = self.station_manager.station_by_name(network_name)
-                if station_data and isinstance(station_data, dict):
-                    self.channel_config = station_data
-                    
-                    if station_data.get("show_logo", True) is False:
-                        station_wants_to_show_logo = False
+                station = self.station_manager.station_by_name(net)
+                if isinstance(station, dict):
+                    self.channel_config = station
+
+                    if station.get("show_logo", True) is False:
+                        show_logo = False
                         self.clear_logo_textures()
                         return
 
-                    logo_path = self.select_logo_for_channel(station_data)
-                    
+                    selected = self.select_logo_for_channel(station)
+                    if selected is not None:
+                        logo_path = selected
                 else:
-                    print(f"[WARNING] StationManager returned no data for {network_name}")
+                    print(f"[WARNING] No station data for {net}")
             except Exception as e:
-                print(f"[ERROR] Failed to get station data for {network_name}: {e}")
+                print(f"[ERROR] Failed to get station data for {net}: {e}")
 
-        if not logo_path and station_wants_to_show_logo:
+        if not logo_path and show_logo:
             if self.config.default_show_logo and self.config.default_logo:
-                default_logo_candidate = Path(self.config.default_logo)
-                if default_logo_candidate.exists():
-                    logo_path = default_logo_candidate
-                    self.is_displaying_osd_default_logo = True # Mark that OSD default is being used
+                candidate = Path(self.config.default_logo)
+                if candidate.exists():
+                    logo_path = candidate
+                    self.is_displaying_osd_default_logo = True
                 else:
-                     print(f"[WARNING] OSD Default logo file not found: {self.config.default_logo}")
+                    print(
+                        f"[WARNING] OSD default logo not found: {self.config.default_logo}"
+                    )
 
+        if logo_path and logo_path.exists():
+            if (
+                self.current_logo_path == str(logo_path)
+                and not (
+                    self.channel_config.get("multi_logo", "single").lower()
+                    in ("multi", "random")
+                    and not self.is_displaying_osd_default_logo
+                )
+            ):
+                return
 
-        if logo_path and Path(logo_path).exists():
-            try:
-                if self.current_logo_path == str(logo_path) and not (
-                    self.channel_config.get("multi_logo", "single").lower() in ["multi", "random"] and \
-                    not self.is_displaying_osd_default_logo):
-                    return 
-
-                self.current_logo_path = str(logo_path)
-                if str(logo_path).lower().endswith('.gif'):
-                    success = self.load_animated_gif(str(logo_path))
-                    if not success:
-                        self.load_static_logo(str(logo_path)) 
-                else:
+            self.current_logo_path = str(logo_path)
+            if str(logo_path).lower().endswith(".gif"):
+                if not self.load_animated_gif(str(logo_path)):
                     self.load_static_logo(str(logo_path))
-            except Exception as e:
-                print(f"[ERROR] Error loading logo {logo_path}: {e}")
-                self.clear_logo_textures()
-                self.is_displaying_osd_default_logo = False
+            else:
+                self.load_static_logo(str(logo_path))
         else:
-            if logo_path:
-                print(f"[WARNING] Logo file not found: {logo_path}")
             self.clear_logo_textures()
             self.is_displaying_osd_default_logo = False
 
+    # -------------------------------------------------------------------------
+    # Update & Draw
+    # -------------------------------------------------------------------------
 
-    def update(self, dt):
+    def update(self, dt: float) -> None:
         self.time_since_change += dt
         self.check_status()
 
         if self.is_animated and self.current_logo_textures:
             self.frame_timer += dt
-            if self.current_frame_index < len(self.current_frame_durations):
-                current_frame_duration = self.current_frame_durations[self.current_frame_index]
-                if current_frame_duration <= 0: 
-                    current_frame_duration = 0.1 
-                if self.frame_timer >= current_frame_duration:
-                    self.frame_timer -= current_frame_duration 
-                    self.current_frame_index = (self.current_frame_index + 1) % len(self.current_logo_textures)
-            elif self.current_logo_textures:
-                 self.current_frame_index = 0
+            dur = self.current_frame_durations[self.current_frame_index]
+            if dur <= 0.0:
+                dur = 0.1
+            if self.frame_timer >= dur:
+                self.frame_timer -= dur
+                self.current_frame_index = (
+                    self.current_frame_index + 1
+                ) % len(self.current_logo_textures)
 
-
-    def draw(self):
-        if not self.current_logo_textures or self.current_frame_index >= len(self.current_logo_textures):
+    def draw(self) -> None:
+        if (
+            not self.current_logo_textures
+            or self.current_frame_index >= len(self.current_logo_textures)
+        ):
             return
 
-        # Only show logos during FEATURE content
         if self.current_content_type != ContentType.FEATURE:
             return
 
-        effective_is_permanent = False
         if self.is_displaying_osd_default_logo:
-            effective_is_permanent = self.config.default_logo_permanent
-        elif self.channel_config: 
-            effective_is_permanent = self.channel_config.get("logo_permanent", False)
+            permanent = self.config.default_logo_permanent
+        else:
+            permanent = self.channel_config.get("logo_permanent", False)
 
-        effective_display_time = self.config.display_time 
-        if not self.is_displaying_osd_default_logo and self.channel_config.get("logo_display_time") is not None:
-            effective_display_time = float(self.channel_config["logo_display_time"])
+        display_time = (
+            float(self.channel_config.get("logo_display_time"))
+            if not self.is_displaying_osd_default_logo
+            and self.channel_config.get("logo_display_time") is not None
+            else self.config.display_time
+        )
 
-        if not effective_is_permanent and not self.config.always_show and self.time_since_change >= effective_display_time:
+        if (
+            not permanent
+            and not self.config.always_show
+            and self.time_since_change >= display_time
+        ):
             return
 
-        current_config_width = self.config.width
-        current_config_height = self.config.height
-        current_config_x_margin = self.config.x_margin
-        current_config_y_margin = self.config.y_margin
-        current_config_halign = self.config.halign
-        current_config_valign = self.config.valign
+        width = float(self.channel_config.get("logo_width", self.config.width))
+        height = float(self.channel_config.get("logo_height", self.config.height))
 
-        if not self.is_displaying_osd_default_logo and self.channel_config:
-            current_config_width = float(self.channel_config.get("logo_width", self.config.width))
-            current_config_height = float(self.channel_config.get("logo_height", self.config.height))
-            current_config_x_margin = float(self.channel_config.get("logo_x_margin", self.config.x_margin))
-            current_config_y_margin = float(self.channel_config.get("logo_y_margin", self.config.y_margin))
-            
-            halign_str_override = self.channel_config.get("logo_halign")
-            if halign_str_override:
-                try:
-                    current_config_halign = HAlignment[halign_str_override.upper()]
-                except KeyError:
-                    pass # Invalid override, use OSD config halign
+        x_margin = float(self.channel_config.get("logo_x_margin", self.config.x_margin))
+        y_margin = float(self.channel_config.get("logo_y_margin", self.config.y_margin))
 
-            valign_str_override = self.channel_config.get("logo_valign")
-            if valign_str_override:
-                try:
-                    current_config_valign = VAlignment[valign_str_override.upper()]
-                except KeyError:
-                    pass # Invalid override, use OSD config valign
+        halign_str = self.channel_config.get("logo_halign", self.config.halign.value)
+        valign_str = self.channel_config.get("logo_valign", self.config.valign.value)
 
-        logo_width_ndc = current_config_width * 2
-        logo_height_ndc = current_config_height * 2
+        try:
+            halign = HAlignment[halign_str.upper()]
+        except Exception:
+            halign = self.config.halign
 
-        if current_config_halign == HAlignment.LEFT:
-            x = -1 + current_config_x_margin
-        elif current_config_halign == HAlignment.RIGHT:
-            x = 1 - logo_width_ndc - current_config_x_margin
-        else: # CENTER
-            x = -logo_width_ndc / 2
+        try:
+            valign = VAlignment[valign_str.upper()]
+        except Exception:
+            valign = self.config.valign
 
-        if current_config_valign == VAlignment.BOTTOM:
-            y = -1 + current_config_y_margin
-        elif current_config_valign == VAlignment.TOP:
-            y = 1 - logo_height_ndc - current_config_y_margin
-        else: # CENTER
-            y = -logo_height_ndc / 2
-        
-        # Bind the current frame's texture
-        current_texture = self.current_logo_textures[self.current_frame_index]
-        glBindTexture(GL_TEXTURE_2D, current_texture)
-        self.draw_logo_quad(x, y, logo_width_ndc, logo_height_ndc)
+        w = width * 2.0
+        h = height * 2.0
 
-    def draw_logo_quad(self, x, y, w, h):
+        if halign == HAlignment.LEFT:
+            x = -1.0 + x_margin
+        elif halign == HAlignment.RIGHT:
+            x = 1.0 - w - x_margin
+        else:
+            x = -w / 2.0
+
+        if valign == VAlignment.BOTTOM:
+            y = -1.0 + y_margin
+        elif valign == VAlignment.TOP:
+            y = 1.0 - h - y_margin
+        else:
+            y = -h / 2.0
+
+        tex = self.current_logo_textures[self.current_frame_index]
+        glBindTexture(GL_TEXTURE_2D, tex)
+        self.draw_logo_quad(x, y, w, h)
+
+    def draw_logo_quad(self, x: float, y: float, w: float, h: float) -> None:
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-        
-        alpha = self.config.default_logo_alpha
-        if not self.is_displaying_osd_default_logo and self.channel_config:
-            alpha = float(self.channel_config.get("logo_alpha", alpha))
-        
-        glColor4f(1, 1, 1, alpha)
+
+        alpha = (
+            self.config.default_logo_alpha
+            if self.is_displaying_osd_default_logo
+            else float(
+                self.channel_config.get("logo_alpha", self.config.default_logo_alpha)
+            )
+        )
+
+        glColor4f(1.0, 1.0, 1.0, alpha)
         glBegin(GL_QUADS)
-        glTexCoord2f(0, 1); glVertex2f(x, y)
-        glTexCoord2f(1, 1); glVertex2f(x + w, y)
-        glTexCoord2f(1, 0); glVertex2f(x + w, y + h)
-        glTexCoord2f(0, 0); glVertex2f(x, y + h)
+        glTexCoord2f(0.0, 1.0)
+        glVertex2f(x, y)
+        glTexCoord2f(1.0, 1.0)
+        glVertex2f(x + w, y)
+        glTexCoord2f(1.0, 0.0)
+        glVertex2f(x + w, y + h)
+        glTexCoord2f(0.0, 0.0)
+        glVertex2f(x, y + h)
         glEnd()
 
-    def __del__(self):
-        if hasattr(self, 'current_logo_textures') and self.current_logo_textures:
+    def __del__(self) -> None:
+        if hasattr(self, "current_logo_textures") and self.current_logo_textures:
             glDeleteTextures(self.current_logo_textures)


### PR DESCRIPTION
### Summary

This PR extends the OSD station logo system to support **time-based** and **content-based** logo selection, while preserving the existing behavior for users who don’t opt in.

Logos can now change automatically based on:

- the **tag** of the scheduled content (e.g. `gameshow`, `awardshow`)
- the **current month** (e.g. `October`, `December 1–31`)
- the **current weekday** (e.g. `Friday`)
- the **current day_part** (e.g. `morning`, `prime`) as defined in `confs/main_config.json`

If none of these hints are configured, logo behavior remains exactly as before:  
it falls back to the standard logo directory and selection logic.

---

### Behavior and Hierarchy

Logo selection happens in a well-defined priority order.  
Given a station with `content_dir` and `logo_dir` configured, the OSD now checks for logos in this hierarchy:

1. **Tag-based folder**  
   `logo_dir/<tag>/`  
   Tag is derived from the station’s schedule (`tags` / `tag` in the day/hour entry).

2. **Most specific temporal match (Month → Weekday → DayPart)**  
   `logo_dir/<Month>/<Weekday>/<day_part>/`  
   Example: `logos/October/Friday/prime/`

3. **Month + Weekday**  
   `logo_dir/<Month>/<Weekday>/`  
   Example: `logos/October/Friday/`

4. **Month + DayPart**  
   `logo_dir/<Month>/<day_part>/`  
   Example: `logos/October/prime/`

5. **Month-only**  
   `logo_dir/<Month>/`  
   or a range like `logo_dir/<Month 1 - Month 31>/`  
   Example: `logos/October/` or `logos/October 1 - October 31/`

6. **Weekday + DayPart (no month)**  
   `logo_dir/<Weekday>/<day_part>/`  
   Example: `logos/Friday/morning/`

7. **Weekday-only (no month)**  
   `logo_dir/<Weekday>/`  
   Example: `logos/Friday/`

8. **DayPart-only (no month)**  
   `logo_dir/<day_part>/`  
   Example: `logos/prime/`

9. **Base directory fallback**  
   If none of the above exist:  
   `logo_dir/`, respecting `default_logo` if set, otherwise a random logo in that directory.

If multiple logos exist in a chosen directory, they are selected randomly (or according to the existing `multi_logo` behavior, unchanged).

---

### Tag-driven Logos

Tags are derived from the station’s existing schedule configuration. No new fields required.

Example schedule:

```json
"monday": {
  "7":  { "tags": "gameshow" },
  "8":  { "tags": "gameshow" },
  "9":  { "tags": "gameshow" },
  "10": { "tags": "gameshow" }
}
```

Example logo directory:

```
catalog/GSN/logos/gameshow/
└── gsn_gameshow_logo.png
```

The OSD will use `logos/gameshow/` whenever the current day/hour matches a `"gameshow"` slot.

If multiple tags are provided as a list, the **first** tag is used as the folder name  
(e.g. `["gameshow", "talkshow"] → logos/gameshow/`).

---

### Day Parts and `main_config.json`

Day parts are read from `confs/main_config.json`.

- `start_hour` / `end_hour` are integers (0–23).  
- Wrap-around windows like `21 → 2` are supported.  

The **day_part name** is used as a directory under `logo_dir`, with spaces replaced by underscores:

- `prime` → `logos/prime/`  
- `late` → `logos/late/`

**Nested usage examples:**

- December prime-time logo: `logos/December/prime/somelogo.png`  
- October Friday morning logo: `logos/October/Friday/morning/mylogo.gif`

If no `day_parts` are defined, that level of the hierarchy is simply skipped.

---

### Backwards Compatibility

If a station only defines `logo_dir` and `show_logo`, and uses a flat logo folder, behavior is unchanged.

`content_dir` and `logo_dir` semantics are preserved:

- If both are present:  
  `base_dir = Path(content_dir) / logo_dir`

- If only `logo_dir`:  
  `base_dir = project_root / logo_dir`

`multi_logo`, `default_logo`, `logo_width`, `logo_height`,  
`logo_x_margin`, `logo_y_margin`, `logo_alpha`, and all other FS42 logo config fields behave exactly as before.

If no matching temporal or tag directories exist, the original base-directory logic is used.

**In other words: if users do nothing, logos behave exactly as they do today.**

---

### Example Setups

Some concrete examples:

#### 1. Seasonal Nickelodeon logo in October prime time

```
catalog/NICK/logos/October/prime/nick_pumpkin.png
```

#### 2. Special “superbowl” bug for all superbowl blocks

```
catalog/CBS/logos/superbowl/CBSfootball.png
```

With schedule entries tagged `"superbowl"`.

#### 3. Friday primetime variant

```
catalog/ABC/logos/Friday/prime/TGIF.png
```

#### 4. December-only logo

```
catalog/NBC/logos/December/holiday_nbc_logo.png
```

Or date-range:

```
catalog/NBC/logos/December 1 - December 31/holiday_nbc_logo.png
```

---

### Files Changed

- `fs42/osd/logo_display.py`

The changes are contained to the OSD logo selection logic and do not modify any scheduler or catalog logic.