### PR TITLE
docs: add virtual environment activation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ For a complete, step-by-step guide to setting up and administering FieldStation4
 * Add your own content (videos)
 * Configure your stations
     * Copy an example json file from `confs/examples` into `confs/`
+* Activate the Virtual Environment
+   * To run FieldStation42 and its tools, you must first activate the virtual environment that was created by the install script with the following command: 
+   ```bash
+   source env/bin/activate
+   ```
+   * While the virtual environment is active, your terminal will show "(env)" at the beginning. 
 * Generate a weekly schedule
     * Run `python3 station_42.py` on the command line
         * Use `--rebuild_catalog` option if content has changed


### PR DESCRIPTION
What this PR does:
Adds clear instructions for activating the virtual environment to the main README's Quickstart guide.

Why this is needed:
Virtual environment activation is a prerequisite to run the FieldStation42 software. This consideration is mentioned in other areas of the project's documentation, but was missing from the main README, leading to confusion for new users.

Changes:
- Added a new section with source env/bin/activate command and explanation.
- Explains what a successful activation looks like ((env) prompt).
- Explains that Python commands will fail without an active environment.