### PR TITLE
Add context-aware coming-up-next bump pool augmentation

### DIFF
--- a/fs42/liquid_blocks.py
+++ b/fs42/liquid_blocks.py
@@ -36,6 +36,12 @@ class LiquidBlock:
         
         self.break_strategy = break_strategy
 
+        # set by liquid_schedule before make_plan() is called
+        self.current_tag = None
+        self.next_tag = None
+        self.next_next_tag = None
+        self.next_next_next_tag = None
+
     def __str__(self):
         content = os.path.basename(self.content.path)
         return f"{self.start_time.strftime('%m/%d %H:%M')} - {self.end_time.strftime('%H:%M')} - {self.title} - {content}"
@@ -167,6 +173,10 @@ class LiquidBlock:
                 commercial_dir=self.commercial_override,
                 bump_dir=self.bump_override,
                 strict_count=strict_count,
+                current_tag=self.current_tag,
+                next_tag=self.next_tag,
+                next_next_tag=self.next_next_tag,
+                next_next_next_tag=self.next_next_next_tag,
             )
             
         else:
@@ -248,7 +258,12 @@ class LiquidClipBlock(LiquidBlock):
             raise (ValueError(err))
         if diff > 2:
             self.reel_blocks = catalog.make_reel_fill(
-                self.start_time, diff, commercial_dir=self.commercial_override, bump_dir=self.bump_override, strict_count=strict_count
+                self.start_time, diff, commercial_dir=self.commercial_override, bump_dir=self.bump_override,
+                strict_count=strict_count,
+                current_tag=self.current_tag,
+                next_tag=self.next_tag,
+                next_next_tag=self.next_next_tag,
+                next_next_next_tag=self.next_next_next_tag,
             )
         else:
             self.reel_blocks = []


### PR DESCRIPTION
Adds support for video bumpers that are contextually aware of what show  is currently playing and what shows are coming up next in the schedule.

When the scheduler builds commercial breaks for a show, it now looks ahead  up to 3 shows in the resolved block queue and passes that context down to  bump selection. At selection time, any matching video files found in a  special next/ folder are merged into the normal bump pool as additional  candidates — they are not prioritized, just added, so they fire naturally  through the existing random selection process.

Folder naming convention in content_dir/next/:
  --ShowB                                          next is ShowB
  --ShowB--ShowC                             next ShowB, then ShowC
  --ShowB--ShowC--ShowD               next ShowB, then ShowC, then ShowD
  ShowA--ShowB                                 watching ShowA, next ShowB
  ShowA--ShowB--ShowC                   watching ShowA, next ShowB, then ShowC
  ShowA--ShowB--ShowC--ShowD     watching ShowA, next ShowB, then ShowC, then ShowD

The feature is fully opt-in — if no next/ folder exists behavior is  identical to before. Compatible with existing hint system (month, day  part, etc) on bumpers in next/ subfolders.

Files changed:
  fs42/liquid_schedule.py — lookahead tag resolution in _fluid()
  fs42/liquid_blocks.py   — tag attributes and pass-through in make_plan()
  fs42/catalog.py         — next/ folder scanning and pool augmentation in find_bump()