### PR TITLE
Allow PPV interface to be controlled via keypress API endpoints

### DIFF
--- a/field_player.py
+++ b/field_player.py
@@ -68,6 +68,9 @@ def input_check():
                 case "play_file":
                     file_path = q_message.get("file_path", None)
                     return PlayerOutcome(PlayerState.PLAY_FILE, file_path)
+                case "web_key":
+                    key = q_message.get("key", "")
+                    return PlayerOutcome(PlayerState.SUCCESS, f"web_key:{key}")
 
 
     channel_socket = StationManager().server_conf["channel_socket"]

--- a/fs42/fs42_server/api/ppv.py
+++ b/fs42/fs42_server/api/ppv.py
@@ -340,3 +340,16 @@ async def play_file(channel_number: int, play_request: PlayFileRequest, request:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to send play command: {str(e)}"
         )
+
+@router.post("/{channel_number}/key/{key_name}")
+async def send_key(channel_number: int, key_name: str, request: Request):
+    """Send a keypress to the PPV web channel."""
+    allowed_keys = {"PageUp", "PageDown", "Enter"}
+    if key_name not in allowed_keys:
+        raise HTTPException(status_code=400, detail=f"Key must be one of: {allowed_keys}")
+    command_queue = request.app.state.player_command_queue
+    try:
+        command_queue.put({"command": "web_key", "key": key_name})
+        return {"success": True, "key": key_name}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -578,12 +578,19 @@ class StationPlayer:
 
             response = self.input_check_fn()
             if response:
-                self._l.info("Sending the web channel shutdown command")
-                self.web_queue.put("hide_window")
-                self.web_process.join()
-                self.web_process = None
-                self.web_queue = None
-                return response
+                # Check if this is a web_key command - forward to web process
+                if response.payload and isinstance(response.payload, str) and response.payload.startswith("web_key:"):
+                    key_name = response.payload[8:]
+                    if self.web_queue:
+                        self.web_queue.put(f"key:{key_name}")
+                        self._l.info(f"Forwarded key '{key_name}' to web process")
+                else:
+                    self._l.info("Sending the web channel shutdown command")
+                    self.web_queue.put("hide_window")
+                    self.web_process.join()
+                    self.web_process = None
+                    self.web_queue = None
+                    return response
         return PlayerOutcome(PlayerState.SUCCESS)
 
     def schedule_panic(self, network_name):

--- a/fs42/webrender/web_render.py
+++ b/fs42/webrender/web_render.py
@@ -153,6 +153,22 @@ class WebRenderApp(QApplication):
                 self.quit()
                 print("WebRender shutdown complete")
                 return
+            # Handle key injection commands
+            if isinstance(msg, str) and msg.startswith("key:"):
+                key_name = msg[4:]
+                if key_name not in {"PageUp", "PageDown", "Enter"}:
+                    print(f"WebRender: rejected disallowed key '{key_name}'")
+                    return
+                js = f"""
+                document.dispatchEvent(new KeyboardEvent('keydown', {{
+                    key: '{key_name}',
+                    code: '{key_name}',
+                    bubbles: true,
+                    cancelable: true
+                }}));
+                """
+                self.window.browser.page().runJavaScript(js)
+                return
 
 def web_render_runner(user_conf, queue):
     # Set up signal handler for web process - just exit cleanly


### PR DESCRIPTION
These few small changes allow you to control the PPV web channel with HTTP POST requests to the PPV's API e.g. `curl -X POST "http://ipaddress:4242/ppv/55/key/PageUp"`. It will only accept the three valid keypresses `PageUp`, `PageDown`, and `Enter` to prevent any shenanigans with injecting other keypresses.

The use case for adding this is the ability to control the PPV interface completely programmatically. For example, I have a UART listener script that listens for messages from a connected Raspberry Pi Pico which receives IR commands from my remote and then relays those commands to the FieldStation42 API. I can now simply have that listener send PageUp and PageDown keypresses to the PPV interface to control it with my remote.

Hopefully this is a useful addition...