### PR TITLE
Enhancements to music video nfo overlays

### DIFF
--- a/fs42/catalog.py
+++ b/fs42/catalog.py
@@ -722,7 +722,10 @@ class ShowCatalog:
                     current_duration += candidate.duration
                     clips.append(candidate)
                 elif projected_duration > target_content_max:
-                    # would exceed maximum - stop here
+                    # for "end" strategy, add the clip if it lands closer to the target than stopping here
+                    if break_strategy == "end" and abs(projected_duration - target_content_max) < abs(current_duration - target_content_max):
+                        current_duration += candidate.duration
+                        clips.append(candidate)
                     keep_going = False
                 elif current_duration >= target_content_min:
                     # we're at or above minimum and under maximum - add the clip

--- a/fs42/catalog.py
+++ b/fs42/catalog.py
@@ -660,7 +660,7 @@ class ShowCatalog:
 
         return blocks
 
-    def gather_clip_content(self, tag, duration, when, start_clip, end_clip):
+    def gather_clip_content(self, tag, duration, when, start_clip, end_clip, break_duration=None, break_strategy=None):
         current_duration = 0
         keep_going = True
         clips = []
@@ -671,8 +671,13 @@ class ShowCatalog:
         CONTENT_RATIO_MAX = 0.80
 
         # calculate target content duration range
-        target_content_min = duration * CONTENT_RATIO_MIN
-        target_content_max = duration * CONTENT_RATIO_MAX
+        # for "end" strategy, break_duration is the total commercial time, so use it directly
+        if break_strategy == "end" and break_duration is not None and break_duration > 0 and break_duration < duration:
+            target_content_max = duration - break_duration
+            target_content_min = target_content_max * CONTENT_RATIO_MIN / CONTENT_RATIO_MAX
+        else:
+            target_content_min = duration * CONTENT_RATIO_MIN
+            target_content_max = duration * CONTENT_RATIO_MAX
 
         if start_clip is not None:
             try:

--- a/fs42/liquid_schedule.py
+++ b/fs42/liquid_schedule.py
@@ -118,8 +118,11 @@ class LiquidSchedule:
         next_mark = None
         # handle clip show
         clip_config = self.conf["clip_shows"][tag_str]
+        break_duration = clip_config.get("break_duration", self.conf.get("break_duration", None))
+        break_strategy = clip_config.get("break_strategy", self.conf.get("break_strategy", None))
         clip_content = self.catalog.gather_clip_content(
-            tag_str, clip_config.get("duration"), current_mark, clip_config.get("start_clip", None), clip_config.get("end_clip", None)
+            tag_str, clip_config.get("duration"), current_mark, clip_config.get("start_clip", None), clip_config.get("end_clip", None),
+            break_duration=break_duration, break_strategy=break_strategy
         )
         if len(clip_content) == 0:
             # this should only happen on an error (have a tag, but no candidate)

--- a/fs42/nfo_agent.py
+++ b/fs42/nfo_agent.py
@@ -63,14 +63,6 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
     body_weight = overlay_cfg["overlay_body_weight"]
     overlay_type = overlay_cfg["overlay_type"]
 
-    font_family = "Arial"
-    if font_path and os.path.exists(font_path):
-        font_id = QFontDatabase.addApplicationFont(font_path)
-        if font_id >= 0:
-            families = QFontDatabase.applicationFontFamilies(font_id)
-            if families:
-                font_family = families[0]
-
     def _qt_weight(weight_str):
         return QFont.Bold if weight_str == "bold" else QFont.Normal
 
@@ -100,6 +92,14 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
                 self.lines = nfo_lines[:2]
             else:
                 self.lines = nfo_lines
+
+            font_family = "Arial"
+            if font_path and os.path.exists(font_path):
+                font_id = QFontDatabase.addApplicationFont(font_path)
+                if font_id >= 0:
+                    families = QFontDatabase.applicationFontFamilies(font_id)
+                    if families:
+                        font_family = families[0]
 
             self.title_font = QFont(font_family, int(title_size * self.scale), _qt_weight(title_weight))
             self.body_font = QFont(font_family, int(body_size * self.scale), _qt_weight(body_weight))

--- a/fs42/nfo_agent.py
+++ b/fs42/nfo_agent.py
@@ -1,13 +1,10 @@
 import os
-import json
 import multiprocessing
 import logging
 
 _logger = logging.getLogger("NFOAgent")
 
 MAX_NFO_LINES = 5
-
-_MAIN_CONFIG_PATH = "confs/main_config.json"
 
 _OVERLAY_DEFAULTS = {
     "overlay_effect": "outline",
@@ -53,17 +50,6 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
     from PySide6.QtGui import QColor, QPainter, QFont, QFontMetrics, QFontDatabase
     from PySide6.QtCore import Qt, QTimer
 
-    effect = overlay_cfg["overlay_effect"]
-    offset_px = overlay_cfg["overlay_offset_px"]
-    font_path = overlay_cfg["overlay_font_path"]
-    text_color = overlay_cfg["overlay_text_color"]
-    shadow_color = overlay_cfg["overlay_shadow_color"]
-    title_size = overlay_cfg["overlay_title_size"]
-    body_size = overlay_cfg["overlay_body_size"]
-    title_weight = overlay_cfg["overlay_title_weight"]
-    body_weight = overlay_cfg["overlay_body_weight"]
-    overlay_type = overlay_cfg["overlay_type"]
-
     def _qt_weight(weight_str):
         return QFont.Bold if weight_str == "bold" else QFont.Normal
 
@@ -89,12 +75,13 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
 
             self.scale = screen_height / 1080.0
 
-            if overlay_type == "minimal":
+            if overlay_cfg["overlay_type"] == "minimal":
                 self.lines = nfo_lines[:2]
             else:
                 self.lines = nfo_lines
 
             font_family = "Arial"
+            font_path = overlay_cfg["overlay_font_path"]
             if font_path and os.path.exists(font_path):
                 font_id = QFontDatabase.addApplicationFont(font_path)
                 if font_id >= 0:
@@ -102,11 +89,11 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
                     if families:
                         font_family = families[0]
 
-            self.title_font = QFont(font_family, int(title_size * self.scale), _qt_weight(title_weight))
-            self.body_font = QFont(font_family, int(body_size * self.scale), _qt_weight(body_weight))
+            self.title_font = QFont(font_family, int(overlay_cfg["overlay_title_size"] * self.scale), _qt_weight(overlay_cfg["overlay_title_weight"]))
+            self.body_font = QFont(font_family, int(overlay_cfg["overlay_body_size"] * self.scale), _qt_weight(overlay_cfg["overlay_body_weight"]))
 
-            self.text_color = QColor(*text_color)
-            self.effect_color = QColor(*shadow_color)
+            self.text_color = QColor(*overlay_cfg["overlay_text_color"])
+            self.effect_color = QColor(*overlay_cfg["overlay_shadow_color"])
             self.opacity = 1.0
 
         def _draw_drop_shadow(self, painter, x, y, text, font, px):
@@ -131,7 +118,7 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
             painter.drawText(x, y, text)
 
         def _draw_text(self, painter, x, y, text, font, px):
-            if effect == "drop_shadow":
+            if overlay_cfg["overlay_effect"] == "drop_shadow":
                 self._draw_drop_shadow(painter, x, y, text, font, px)
             else:
                 self._draw_outline(painter, x, y, text, font, px)
@@ -155,7 +142,7 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
             scale = self.scale
             margin_x = int(80 * scale)
             margin_y = int(80 * scale)
-            px = max(1, int(offset_px * scale))
+            px = max(1, int(overlay_cfg["overlay_offset_px"] * scale))
 
             title_metrics = QFontMetrics(self.title_font)
             body_metrics = QFontMetrics(self.body_font)
@@ -183,11 +170,10 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
             painter.drawPixmap(0, 0, pixmap)
             painter.end()
 
-    FADE_DURATION_MS = overlay_cfg["overlay_fade_duration_ms"]
     FADE_INTERVAL_MS = 30  # ~33 fps
 
     def fade_out(on_done=None):
-        steps = max(1, FADE_DURATION_MS // FADE_INTERVAL_MS)
+        steps = max(1, overlay_cfg["overlay_fade_duration_ms"] // FADE_INTERVAL_MS)
         step_size = 1.0 / steps
         timer = QTimer()
 
@@ -206,7 +192,7 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
     def fade_in():
         window.opacity = 0.0
         window.show()
-        steps = max(1, FADE_DURATION_MS // FADE_INTERVAL_MS)
+        steps = max(1, overlay_cfg["overlay_fade_duration_ms"] // FADE_INTERVAL_MS)
         step_size = 1.0 / steps
         timer = QTimer()
 
@@ -253,14 +239,14 @@ class NFOAgent:
     def _load_overlay_config():
         cfg = dict(_OVERLAY_DEFAULTS)
         try:
-            if os.path.exists(_MAIN_CONFIG_PATH):
-                with open(_MAIN_CONFIG_PATH, "r", encoding="utf-8") as f:
-                    main_cfg = json.load(f)
-                for key in _OVERLAY_DEFAULTS:
-                    if key in main_cfg:
-                        cfg[key] = main_cfg[key]
+            from fs42.station_manager import StationManager
+            main_conf = StationManager().server_conf
+            overlay_conf = main_conf.get("overlay_conf", {})
+            for key in _OVERLAY_DEFAULTS:
+                if key in overlay_conf:
+                    cfg[key] = overlay_conf[key]
         except Exception as e:
-            _logger.warning(f"Could not load overlay config from {_MAIN_CONFIG_PATH}: {e}")
+            _logger.warning(f"Could not load overlay config from StationManager: {e}")
         return cfg
 
     @staticmethod

--- a/fs42/nfo_agent.py
+++ b/fs42/nfo_agent.py
@@ -14,7 +14,7 @@ _OVERLAY_DEFAULTS = {
     "overlay_offset_px": 2,
     "overlay_font_path": None,
     "overlay_text_color": [255, 255, 255, 255],
-    "overlay_shadow_colour": [0, 0, 0, 255],
+    "overlay_shadow_color": [0, 0, 0, 255],
     "overlay_title_size": 30,
     "overlay_body_size": 20,
     "overlay_title_weight": "bold",
@@ -56,7 +56,7 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
     offset_px = overlay_cfg["overlay_offset_px"]
     font_path = overlay_cfg["overlay_font_path"]
     text_color = overlay_cfg["overlay_text_color"]
-    shadow_colour = overlay_cfg["overlay_shadow_colour"]
+    shadow_color = overlay_cfg["overlay_shadow_color"]
     title_size = overlay_cfg["overlay_title_size"]
     body_size = overlay_cfg["overlay_body_size"]
     title_weight = overlay_cfg["overlay_title_weight"]
@@ -105,7 +105,7 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
             self.body_font = QFont(font_family, int(body_size * self.scale), _qt_weight(body_weight))
 
             self.text_color = QColor(*text_color)
-            self.effect_color = QColor(*shadow_colour)
+            self.effect_color = QColor(*shadow_color)
 
         def _draw_drop_shadow(self, painter, x, y, text, font, px):
             painter.setFont(font)

--- a/fs42/nfo_agent.py
+++ b/fs42/nfo_agent.py
@@ -110,7 +110,8 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
         def _draw_drop_shadow(self, painter, x, y, text, font, px):
             painter.setFont(font)
             painter.setPen(self.effect_color)
-            painter.drawText(x + px, y + px, text)
+            for i in range(1, px + 1):
+                painter.drawText(x + i, y + i, text)
             painter.setPen(self.text_color)
             painter.drawText(x, y, text)
 

--- a/fs42/nfo_agent.py
+++ b/fs42/nfo_agent.py
@@ -1,10 +1,26 @@
 import os
+import json
 import multiprocessing
 import logging
 
 _logger = logging.getLogger("NFOAgent")
 
 MAX_NFO_LINES = 5
+
+_MAIN_CONFIG_PATH = "confs/main_config.json"
+
+_OVERLAY_DEFAULTS = {
+    "overlay_effect": "outline",
+    "overlay_offset_px": 2,
+    "overlay_font_path": None,
+    "overlay_text_color": [255, 255, 255, 255],
+    "overlay_shadow_colour": [0, 0, 0, 255],
+    "overlay_title_size": 30,
+    "overlay_body_size": 20,
+    "overlay_title_weight": "bold",
+    "overlay_body_weight": "normal",
+    "overlay_type": "normal",
+}
 
 
 class NFOData:
@@ -28,13 +44,35 @@ class NFOData:
 DEFAULT_SHOW_SECONDS = 10
 
 
-def _run_overlay_app(lines, play_duration, show_seconds):
+def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
 
     import sys
     import signal
     from PySide6.QtWidgets import QApplication, QWidget
-    from PySide6.QtGui import QColor, QPainter, QFont, QFontMetrics
+    from PySide6.QtGui import QColor, QPainter, QFont, QFontMetrics, QFontDatabase
     from PySide6.QtCore import Qt, QTimer
+
+    effect = overlay_cfg["overlay_effect"]
+    offset_px = overlay_cfg["overlay_offset_px"]
+    font_path = overlay_cfg["overlay_font_path"]
+    text_color = overlay_cfg["overlay_text_color"]
+    shadow_colour = overlay_cfg["overlay_shadow_colour"]
+    title_size = overlay_cfg["overlay_title_size"]
+    body_size = overlay_cfg["overlay_body_size"]
+    title_weight = overlay_cfg["overlay_title_weight"]
+    body_weight = overlay_cfg["overlay_body_weight"]
+    overlay_type = overlay_cfg["overlay_type"]
+
+    font_family = "Arial"
+    if font_path and os.path.exists(font_path):
+        font_id = QFontDatabase.addApplicationFont(font_path)
+        if font_id >= 0:
+            families = QFontDatabase.applicationFontFamilies(font_id)
+            if families:
+                font_family = families[0]
+
+    def _qt_weight(weight_str):
+        return QFont.Bold if weight_str == "bold" else QFont.Normal
 
     class NFOOverlayWindow(QWidget):
         def __init__(self, nfo_lines):
@@ -57,26 +95,43 @@ def _run_overlay_app(lines, play_duration, show_seconds):
                 screen_height = 1080
 
             self.scale = screen_height / 1080.0
-            self.lines = nfo_lines
 
-            self.title_font = QFont("Arial", int(30 * self.scale), QFont.Bold)
-            self.body_font = QFont("Arial", int(20 * self.scale), QFont.Normal)
+            if overlay_type == "minimal":
+                self.lines = nfo_lines[:2]
+            else:
+                self.lines = nfo_lines
 
-            self.white = QColor(255, 255, 255)
-            self.outline = QColor(0, 0, 0)
+            self.title_font = QFont(font_family, int(title_size * self.scale), _qt_weight(title_weight))
+            self.body_font = QFont(font_family, int(body_size * self.scale), _qt_weight(body_weight))
 
-        def _draw_outlined_text(self, painter, x, y, text, font, outline_px=2):
+            self.text_color = QColor(*text_color)
+            self.effect_color = QColor(*shadow_colour)
+
+        def _draw_drop_shadow(self, painter, x, y, text, font, px):
+            painter.setFont(font)
+            painter.setPen(self.effect_color)
+            painter.drawText(x + px, y + px, text)
+            painter.setPen(self.text_color)
+            painter.drawText(x, y, text)
+
+        def _draw_outline(self, painter, x, y, text, font, px):
             painter.setFont(font)
             offsets = [
-                (-outline_px, -outline_px), (0, -outline_px), (outline_px, -outline_px),
-                (-outline_px,  0),                             (outline_px,  0),
-                (-outline_px,  outline_px), (0,  outline_px), (outline_px,  outline_px),
+                (-px, -px), (0, -px), (px, -px),
+                (-px,   0),           (px,   0),
+                (-px,  px), (0,  px), (px,  px),
             ]
-            painter.setPen(self.outline)
+            painter.setPen(self.effect_color)
             for dx, dy in offsets:
                 painter.drawText(x + dx, y + dy, text)
-            painter.setPen(self.white)
+            painter.setPen(self.text_color)
             painter.drawText(x, y, text)
+
+        def _draw_text(self, painter, x, y, text, font, px):
+            if effect == "drop_shadow":
+                self._draw_drop_shadow(painter, x, y, text, font, px)
+            else:
+                self._draw_outline(painter, x, y, text, font, px)
 
         def paintEvent(self, event):
             if not self.lines:
@@ -89,7 +144,7 @@ def _run_overlay_app(lines, play_duration, show_seconds):
             scale = self.scale
             margin_x = int(80 * scale)
             margin_y = int(80 * scale)
-            outline_px = max(2, int(2 * scale))
+            px = max(1, int(offset_px * scale))
 
             title_metrics = QFontMetrics(self.title_font)
             body_metrics = QFontMetrics(self.body_font)
@@ -97,17 +152,17 @@ def _run_overlay_app(lines, play_duration, show_seconds):
             title_line_h = int(title_metrics.height() * 1.2)
             body_line_h = int(body_metrics.height() * 1.2)
 
-            # Calculate total block height so we can anchor to the bottom
+            # Anchor to the bottom of the screen
             total_h = title_line_h + body_line_h * (len(self.lines) - 1)
             start_y = self.height() - margin_y - total_h
 
             x = margin_x
             y = start_y + title_metrics.ascent()
-            self._draw_outlined_text(painter, x, y, self.lines[0], self.title_font, outline_px)
+            self._draw_text(painter, x, y, self.lines[0], self.title_font, px)
 
             y += title_line_h
             for line in self.lines[1:]:
-                self._draw_outlined_text(painter, x, y, line, self.body_font, outline_px)
+                self._draw_text(painter, x, y, line, self.body_font, px)
                 y += body_line_h
 
             painter.end()
@@ -140,6 +195,20 @@ def _run_overlay_app(lines, play_duration, show_seconds):
 
 class NFOAgent:
     """Static utility for NFO sidecar files and their now-playing overlay."""
+
+    @staticmethod
+    def _load_overlay_config():
+        cfg = dict(_OVERLAY_DEFAULTS)
+        try:
+            if os.path.exists(_MAIN_CONFIG_PATH):
+                with open(_MAIN_CONFIG_PATH, "r", encoding="utf-8") as f:
+                    main_cfg = json.load(f)
+                for key in _OVERLAY_DEFAULTS:
+                    if key in main_cfg:
+                        cfg[key] = main_cfg[key]
+        except Exception as e:
+            _logger.warning(f"Could not load overlay config from {_MAIN_CONFIG_PATH}: {e}")
+        return cfg
 
     @staticmethod
     def _parse_xml_nfo(content):
@@ -212,9 +281,10 @@ class NFOAgent:
         if nfo_data is None:
             return None
         try:
+            overlay_cfg = NFOAgent._load_overlay_config()
             process = multiprocessing.Process(
                 target=_run_overlay_app,
-                args=(nfo_data.lines, play_duration, show_seconds),
+                args=(nfo_data.lines, play_duration, show_seconds, overlay_cfg),
                 daemon=True,
             )
             process.start()

--- a/fs42/nfo_agent.py
+++ b/fs42/nfo_agent.py
@@ -20,6 +20,7 @@ _OVERLAY_DEFAULTS = {
     "overlay_title_weight": "bold",
     "overlay_body_weight": "normal",
     "overlay_type": "normal",
+    "overlay_fade_duration_ms": 600,
 }
 
 
@@ -106,6 +107,7 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
 
             self.text_color = QColor(*text_color)
             self.effect_color = QColor(*shadow_color)
+            self.opacity = 1.0
 
         def _draw_drop_shadow(self, painter, x, y, text, font, px):
             painter.setFont(font)
@@ -138,9 +140,17 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
             if not self.lines:
                 return
 
-            painter = QPainter(self)
-            painter.setRenderHint(QPainter.Antialiasing)
-            painter.setRenderHint(QPainter.TextAntialiasing)
+            from PySide6.QtGui import QPixmap
+
+            # Render text and effect to an off-screen pixmap at full opacity so
+            # overlapping shadow copies composite correctly, then draw the whole
+            # pixmap onto the widget at self.opacity so everything fades as one.
+            pixmap = QPixmap(self.size())
+            pixmap.fill(Qt.transparent)
+
+            pm = QPainter(pixmap)
+            pm.setRenderHint(QPainter.Antialiasing)
+            pm.setRenderHint(QPainter.TextAntialiasing)
 
             scale = self.scale
             margin_x = int(80 * scale)
@@ -159,14 +169,56 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
 
             x = margin_x
             y = start_y + title_metrics.ascent()
-            self._draw_text(painter, x, y, self.lines[0], self.title_font, px)
+            self._draw_text(pm, x, y, self.lines[0], self.title_font, px)
 
             y += title_line_h
             for line in self.lines[1:]:
-                self._draw_text(painter, x, y, line, self.body_font, px)
+                self._draw_text(pm, x, y, line, self.body_font, px)
                 y += body_line_h
 
+            pm.end()
+
+            painter = QPainter(self)
+            painter.setOpacity(self.opacity)
+            painter.drawPixmap(0, 0, pixmap)
             painter.end()
+
+    FADE_DURATION_MS = overlay_cfg["overlay_fade_duration_ms"]
+    FADE_INTERVAL_MS = 30  # ~33 fps
+
+    def fade_out(on_done=None):
+        steps = max(1, FADE_DURATION_MS // FADE_INTERVAL_MS)
+        step_size = 1.0 / steps
+        timer = QTimer()
+
+        def tick():
+            window.opacity = max(0.0, window.opacity - step_size)
+            window.update()
+            if window.opacity <= 0.0:
+                timer.stop()
+                if on_done:
+                    on_done()
+
+        window._fade_timer = timer  # prevent GC
+        timer.timeout.connect(tick)
+        timer.start(FADE_INTERVAL_MS)
+
+    def fade_in():
+        window.opacity = 0.0
+        window.show()
+        steps = max(1, FADE_DURATION_MS // FADE_INTERVAL_MS)
+        step_size = 1.0 / steps
+        timer = QTimer()
+
+        def tick():
+            window.opacity = min(1.0, window.opacity + step_size)
+            window.update()
+            if window.opacity >= 1.0:
+                timer.stop()
+
+        window._fade_timer = timer  # prevent GC
+        timer.timeout.connect(tick)
+        timer.start(FADE_INTERVAL_MS)
 
     def signal_handler(sig, frame):
         QApplication.quit()
@@ -183,12 +235,12 @@ def _run_overlay_app(lines, play_duration, show_seconds, overlay_cfg):
     if play_duration is not None and play_duration > show_seconds * 2:
         hide_timer = QTimer()
         hide_timer.setSingleShot(True)
-        hide_timer.timeout.connect(window.hide)
+        hide_timer.timeout.connect(lambda: fade_out(on_done=window.hide))
         hide_timer.start(int(show_seconds * 1000))
 
         show_timer = QTimer()
         show_timer.setSingleShot(True)
-        show_timer.timeout.connect(window.show)
+        show_timer.timeout.connect(fade_in)
         show_timer.start(int((play_duration - show_seconds) * 1000))
 
     sys.exit(app.exec())

--- a/fs42/osd/logo_display.py
+++ b/fs42/osd/logo_display.py
@@ -153,16 +153,23 @@ class LogoDisplay(object):
         else:
             return None
 
+        stripped = first_tag.strip()
         safe = (
-            first_tag.strip()
+            stripped
             .replace(" ", "_")
             .replace("/", "_")
             .replace("\\", "_")
             .replace(":", "_")
         )
         candidate = base_dir / safe
+
         if candidate.exists() and candidate.is_dir():
             return candidate
+
+        if stripped != safe:
+            candidate_orig = base_dir / stripped
+            if candidate_orig.exists() and candidate_orig.is_dir():
+                return candidate_orig
         return None
 
     # -------------------------------------------------------------------------
@@ -445,9 +452,9 @@ class LogoDisplay(object):
             if prev_type != ContentType.FEATURE and new_type == ContentType.FEATURE:
                 self.time_since_change = 0.0
 
-            # For multi-logo stations, reshuffle on each title change
-            if multi_setting in ("multi",):
-                self.load_logo_for_channel(status)
+            # Reload logo on any title change — show-specific (tag-based) logos
+            # may differ between shows, and multi-logo stations should reshuffle
+            self.load_logo_for_channel(status)
 
             return
 


### PR DESCRIPTION
# NFO overlay enhancements

Configurable text effect, font, colours, sizes, and display type for the music video NFO overlay, customised via `confs/main_config.json`. Also, a configurable fade duration for fading out the overlay at the start of the video and fading in towards the end of the video.

## Overlay effect

Two effects are (currently) supported via `overlay_effect`:

- `"outline"` — outlines the text
- `"drop_shadow"` — draws `overlay_offset_px` copies of the text at increasing offsets (1 px, 2 px, … n px) down and to the right, then draws the main text on top to produce a graduated drop shadow effect

The offset distance for both effects is controlled by `overlay_offset_px`.

## Font

Set `overlay_font_path` to an absolute path to a TTF file to use a custom font. If the path is omitted or the file is not found, the overlay falls back to Arial.

## Overlay type

`overlay_type` controls how many fields are shown:

- `"normal"` — artist, title, album, and year
- `"minimal"` — artist and title only

## All options

| Key | Default | Description |
|-----|---------|-------------|
| `overlay_effect` | `"outline"` | `"outline"` or `"drop_shadow"` |
| `overlay_offset_px` | `2` | Pixel offset for the effect |
| `overlay_font_path` | `null` | Absolute path to a TTF font file |
| `overlay_text_color` | `[255, 255, 255, 255]` | Main text color as RGBA |
| `overlay_shadow_color` | `[0, 0, 0, 255]` | Outline/shadow color as RGBA |
| `overlay_title_size` | `30` | Title font size in points |
| `overlay_body_size` | `20` | Body font size in points |
| `overlay_title_weight` | `"bold"` | `"bold"` or `"normal"` |
| `overlay_body_weight` | `"normal"` | `"bold"` or `"normal"` |
| `overlay_type` | `"normal"` | `"normal"` or `"minimal"` |
| `overlay_fade_duration_ms` | `600` | Fade duration in milliseconds |

## Example configuration

```json
  "overlay_conf": {
    "overlay_effect": "drop_shadow",
    "overlay_offset_px": 7,
    "overlay_font_path": "/home/pi/kabel.ttf",
    "overlay_text_color": [255, 255, 255, 255],
    "overlay_shadow_color": [0, 0, 0, 255],
    "overlay_title_size": 30,
    "overlay_body_size": 30,
    "overlay_title_weight": "bold",
    "overlay_body_weight": "bold",
    "overlay_type": "minimal",
    "overlay_fade_duration_ms": 600
  }
```

This uses the Kabel font (the one used by MTV through the 80s and 90s) with a 7px drop shadow, white text on black, both title and body at size 30, and minimal display (artist and title only).