### PR TITLE
Fix to ensure overlay_conf is loaded.

### DIFF
--- a/fs42/station_manager.py
+++ b/fs42/station_manager.py
@@ -115,7 +115,8 @@ class StationManager(object):
                     "tmdb_api_key",
                     "recall_last_channel",
                     "schedule_agent",
-                    "video_seek_timeout"
+                    "video_seek_timeout",
+                    "overlay_conf",
                 ]
 
                 for key in to_check:


### PR DESCRIPTION
Hey Shane. Tiny fix required here... The `overlay_conf` block in the main_config.json just needs adding to the allow list in station_manager.py, as in this fix branch.