### PR TITLE
Special sauce filter and audio filter functionality

### DIFF
--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -117,6 +117,30 @@ class StationPlayer:
             "format=yuv420p,"
             "scale=640:480:flags=neighbor"
             "]"
+        ),
+        "glitchtastic" : (
+            "lavfi=["
+            "scale=360:240:flags=fast_bilinear,"
+            "format=gbrp,"
+            "geq="
+            "r='if(gt(pow(abs(sin(N*0.08)*sin(N*0.11)),0.15),0.7),"
+            "p(mod(X+80*sin(2*PI*Y/45+N*0.4)+20*sin(2*PI*Y/13+N*0.7),W),Y),"
+            "if(gt(mod(Y+N*4,H),H-30),255-p(X,Y),"
+            "p(X+15*sin(2*PI*Y/45+N*0.4),Y)))':"
+            "g='if(gt(pow(abs(sin(N*0.08)*sin(N*0.11)),0.15),0.7),"
+            "p(mod(X+70*sin(2*PI*Y/48+N*0.43)+17*sin(2*PI*Y/14+N*0.73),W),Y),"
+            "if(gt(mod(Y+N*4,H),H-30),255-p(X,Y),"
+            "p(X+12*sin(2*PI*Y/48+N*0.43),Y)))':"
+            "b='if(gt(pow(abs(sin(N*0.08)*sin(N*0.11)),0.15),0.7),"
+            "p(mod(X+60*sin(2*PI*Y/50+N*0.46)+13*sin(2*PI*Y/15+N*0.76),W),Y),"
+            "if(gt(mod(Y+N*4,H),H-30),255-p(X,Y),"
+            "p(X+10*sin(2*PI*Y/50+N*0.46),Y)))'"
+            ":interpolation=nearest,"
+            "noise=alls=15:allf=t,"
+            "eq=contrast=1.2:brightness=-0.05:saturation=1.2,"
+            "format=yuv420p,"
+            "scale=640:480:flags=neighbor"
+            "]"
         )
     }
 

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -102,7 +102,26 @@ class StationPlayer:
             "b='p(X + 24*sin(2*PI*Y/68) +  8*sin(2*PI*N/12), Y)',"
             "scale=640:480:flags=neighbor"
             "]"
+        ),
+        "special_sauce" : (
+            "lavfi=["
+            "scale=360:240:flags=fast_bilinear,"
+            "format=gbrp,"
+            "geq="
+            "r='p(mod(X + 80*sin(2*PI*Y/45 + N*0.4) + 20*sin(2*PI*Y/13 + N*0.7),W), Y)':"
+            "g='p(mod(X + 70*sin(2*PI*Y/48 + N*0.43) + 17*sin(2*PI*Y/14 + N*0.73),W), Y)':"
+            "b='p(mod(X + 60*sin(2*PI*Y/50 + N*0.46) + 13*sin(2*PI*Y/15 + N*0.76),W), Y)'"
+            ":interpolation=nearest,"
+            "noise=alls=15:allf=t,"
+            "eq=contrast=1.2:brightness=-0.05:saturation=1.2,"
+            "format=yuv420p,"
+            "scale=640:480:flags=neighbor"
+            "]"
         )
+    }
+
+    audio_scramble_effects = {
+        "special_sauce": "lavfi=[afreqshift=shift=-2000,vibrato=f=2.5:d=0.4,volume=0.8]"
     }
 
     def __init__(self, station_config, input_check_fn, mpv=None):
@@ -353,6 +372,7 @@ class StationPlayer:
         self._l.info(f"Play and wait on file {file_path}")
         self._close_now_playing()
         self.mpv.vf = ""
+        self.mpv.af = ""
         self.mpv.command("playlist-clear")
         self.mpv.command("loadfile", file_path, "replace")
         self.mpv.loop_playlist = "inf"
@@ -446,6 +466,20 @@ class StationPlayer:
             self.skip_reception_check = False
             self.mpv.vf = ""
             self.scrambler = None
+
+        # Apply audio scramble filter if configured
+        afx = None
+        if "audio_scramble_fx" in self.station_config:
+            afx = self.station_config["audio_scramble_fx"]
+        if slot and "audio_scramble_fx" in slot:
+            afx = slot["audio_scramble_fx"]
+        if afx:
+            if afx in self.audio_scramble_effects:
+                self.mpv.af = self.audio_scramble_effects[afx]
+            else:
+                self._l.warning(f"Audio scramble effect '{afx}' does not exist.")
+        else:
+            self.mpv.af = ""
 
     def play_image(self, duration):
         pass

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -160,7 +160,7 @@ class StationPlayer:
         self.scrambler = None
         self.now_playing_process = None
         self.schedule_lock = None
-        self._base_af = self.mpv.af or ""
+        self._active_afx = None
 
     def load_up(self):
         start_time = time.perf_counter()
@@ -476,11 +476,14 @@ class StationPlayer:
             afx = slot["audio_scramble_fx"]
         if afx:
             if afx in self.audio_scramble_effects:
-                self.mpv.af = self.audio_scramble_effects[afx]
+                self.mpv.command("af", "add", self.audio_scramble_effects[afx])
+                self._active_afx = self.audio_scramble_effects[afx]
             else:
                 self._l.warning(f"Audio scramble effect '{afx}' does not exist.")
         else:
-            self.mpv.af = self._base_af
+            if self._active_afx:
+                self.mpv.command("af", "remove", self._active_afx)
+                self._active_afx = None
 
     def play_image(self, duration):
         pass

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -121,7 +121,11 @@ class StationPlayer:
     }
 
     audio_scramble_effects = {
-        "special_sauce": "lavfi=[afreqshift=shift=-2000,vibrato=f=2.5:d=0.4,volume=0.8]"
+        "special_sauce": "lavfi=[afreqshift=shift=-2000,vibrato=f=2.5:d=0.4,volume=0.8]",
+        "the_jitters": "lavfi=[afreqshift=shift=-3000,aecho=0.6:0.5:50|80:0.4|0.3,tremolo=f=8:d=0.9,volume=0.7]",
+        "possessed": "lavfi=[chorus=0.3:0.3:40|60|80:0.4|0.3|0.2:0.8|1.2|1.6:3|4|5,afreqshift=shift=-1500,lowpass=f=2500,volume=0.8]",
+        "demonic": "lavfi=[rubberband=pitch=0.5,chorus=0.3:0.3:40|60:0.4|0.3:1.0|1.4:3|4,volume=1.0]",
+        "slightly_borked": "lavfi=[acrusher=bits=3:samples=12:lfo=true:lforange=50:lforate=0.3,vibrato=f=3:d=0.5,volume=0.25]"
     }
 
     def __init__(self, station_config, input_check_fn, mpv=None):

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -160,6 +160,7 @@ class StationPlayer:
         self.scrambler = None
         self.now_playing_process = None
         self.schedule_lock = None
+        self._base_af = self.mpv.af or ""
 
     def load_up(self):
         start_time = time.perf_counter()
@@ -479,7 +480,7 @@ class StationPlayer:
             else:
                 self._l.warning(f"Audio scramble effect '{afx}' does not exist.")
         else:
-            self.mpv.af = ""
+            self.mpv.af = self._base_af
 
     def play_image(self, duration):
         pass

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -474,16 +474,15 @@ class StationPlayer:
             afx = self.station_config["audio_scramble_fx"]
         if slot and "audio_scramble_fx" in slot:
             afx = slot["audio_scramble_fx"]
-        if afx:
-            if afx in self.audio_scramble_effects:
-                self.mpv.command("af", "add", self.audio_scramble_effects[afx])
-                self._active_afx = self.audio_scramble_effects[afx]
-            else:
-                self._l.warning(f"Audio scramble effect '{afx}' does not exist.")
-        else:
-            if self._active_afx:
-                self.mpv.command("af", "remove", self._active_afx)
-                self._active_afx = None
+        new_afx = self.audio_scramble_effects.get(afx) if afx else None
+        if self._active_afx and self._active_afx != new_afx:
+            self.mpv.command("af", "remove", self._active_afx)
+            self._active_afx = None
+        if new_afx and new_afx != self._active_afx:
+            self.mpv.command("af", "add", new_afx)
+            self._active_afx = new_afx
+        elif afx and afx not in self.audio_scramble_effects:
+            self._l.warning(f"Audio scramble effect '{afx}' does not exist.")
 
     def play_image(self, duration):
         pass


### PR DESCRIPTION
This adds a new `"special_sauce"` video scramble effect which aims to emulate an authentic scrambled cable TV channel as best as possible. It also adds the ability to add audio scramble effects, which are also mpv filters similar to the video ones. These can be applied in the same way as video scramble effects, by naming and adding the filter to the `fs42/station_player.py` file and then adding the audio scramble effect to the channel's config file as `"audio_scramble_fx"`.

An example `"special_sauce"` audio scramble effect has been added, which pairs well with the similarly named video scramble effect that I've added. The two new filters can be added as follows:

```
"video_scramble_fx": "special_sauce",
"audio_scramble_fx": "special_sauce"
```