### PR TITLE
Add cross-channel sibling exclusion to prevent overlapping movie schedules

### DIFF
--- a/fs42/catalog.py
+++ b/fs42/catalog.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os.path
 import sys
@@ -41,6 +42,22 @@ class bcolors:
 class ShowCatalog:
     prebump = "prebump"
     postbump = "postbump"
+
+    # Tracks content_dirs already scanned by FluidBuilder in this process run.
+    # Prevents redundant directory walks when multiple stations share the same
+    # content_dir (e.g. Comedy 1-4 all under catalog/movies).
+    _fluid_cache_scanned: set = set()
+
+    @classmethod
+    def clear_fluid_cache(cls):
+        """Clear the in-process fluid file cache deduplication set.
+
+        Must be called before starting a fresh catalog rebuild in a long-running
+        process (e.g. the web server API) so that scan_file_cache runs again for
+        each unique content_dir.  In short-lived processes (station_42.py) this
+        is a no-op since the set is always empty at process start.
+        """  
+        cls._fluid_cache_scanned.clear()
 
     def __init__(self, config, rebuild_catalog=False, load=True, debug=False, force=False, skip_chapter_scan=False):
         self.config = config
@@ -106,9 +123,14 @@ class ShowCatalog:
 
                     self.__fluid_builder = FluidBuilder()
                     media_filter = self.config.get("media_filter", "video")
-                    self._l.info("Initializing fluid file cache...")
-                    self.__fluid_builder.scan_file_cache(self.config["content_dir"], media_filter)
-                    self._l.info("Fluid file cache updated - continuing build")
+                    cache_key = (os.path.realpath(self.config["content_dir"]), media_filter)
+                    if cache_key not in ShowCatalog._fluid_cache_scanned:
+                        self._l.info("Initializing fluid file cache...")
+                        self.__fluid_builder.scan_file_cache(self.config["content_dir"], media_filter)
+                        ShowCatalog._fluid_cache_scanned.add(cache_key)
+                        self._l.info("Fluid file cache updated - continuing build")
+                    else:
+                        self._l.info("Fluid file cache already scanned for this content_dir - skipping")
 
                 return self._build_standard()
             case "loop":
@@ -219,7 +241,7 @@ class ShowCatalog:
             total_count += self._scan_directory(tag)
 
         # add commercial and bumps to the tags
-        if "commercial_dir" in self.config:
+        if "commercial_dir" in self.config and self.config["commercial_dir"]:
             total_count += self._scan_directory(self.config["commercial_dir"], content_type="commercial")
         # setup the general bump dir
         if "bump_dir" in self.config and self.config["bump_dir"]:
@@ -288,6 +310,9 @@ class ShowCatalog:
 
     def _scan_directory(self, tag, is_bumps=False, content_type="feature"):
         count_added = 0
+        if not tag:
+            self._l.debug("Skipping _scan_directory call with empty tag - check commercial_dir or clip_shows config")
+            return 0
         if tag not in self.clip_index:
             self.clip_index[tag] = []
             media_filter = self.config.get("media_filter", "video")
@@ -447,8 +472,15 @@ class ShowCatalog:
         else:
             return None
 
-    def find_candidate(self, tag, seconds, when):
+    def find_candidate(self, tag, seconds, when, exclusion_index=None, proposed_start=None):
+        """Find the best candidate for a given tag and duration.
 
+        exclusion_index: optional dict of {realpath: [(start, end), ...]} built from
+            sibling channels sharing the same content_dir.  Candidates whose file is
+            already playing on a sibling channel in an overlapping window are skipped.
+        proposed_start: the datetime at which this slot would begin (required when
+            exclusion_index is provided).
+        """
         if tag in self.clip_index and len(self.clip_index[tag]):
             candidates = self.clip_index[tag]
             matches = []
@@ -459,6 +491,20 @@ class ShowCatalog:
                     and candidate.duration >= 1
                     and MediaProcessor._test_candidate_hints(candidate.hints, when)
                 ):
+                    # skip if a sibling channel is already playing this file in an
+                    # overlapping time window (handles same-start AND mid-play overlap)
+                    if (
+                        exclusion_index is not None
+                        and proposed_start is not None
+                        and candidate.realpath
+                        and candidate.realpath in exclusion_index
+                    ):
+                        proposed_end = proposed_start + datetime.timedelta(seconds=candidate.duration)
+                        if any(
+                            proposed_start < w_end and w_start < proposed_end
+                            for w_start, w_end in exclusion_index[candidate.realpath]
+                        ):
+                            continue
                     matches.append(candidate)
             #random.shuffle(matches)
             if not len(matches):

--- a/fs42/fs42_server/api/build.py
+++ b/fs42/fs42_server/api/build.py
@@ -23,6 +23,11 @@ async def rebuild_catalog(network_name: str, request: Request):
         rebuild_tasks[task_id] = {"status": "starting", "log": ""}
 
     def rebuild_worker():
+        # Clear the fluid file cache dedup set so scan_file_cache runs fresh
+        # for each unique content_dir in this rebuild pass.  Without this, a
+        # second rebuild request in the same server process would silently skip
+        # all directory scans, missing any files added since the first request.
+        ShowCatalog.clear_fluid_cache()
         try:
             with rebuild_tasks_lock:
                 rebuild_tasks[task_id]["status"] = "running"

--- a/fs42/liquid_schedule.py
+++ b/fs42/liquid_schedule.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 import sys
 
 sys.path.append(os.getcwd())
@@ -15,6 +16,8 @@ from fs42.catalog_api import CatalogAPI
 from fs42.liquid_api import LiquidAPI
 from fs42.marathon_agent import MarathonAgent
 from fs42.path_query import PathQuery
+from fs42.station_manager import StationManager
+from fs42.liquid_io import LiquidIO
 
 # logging.basicConfig(format="%(asctime)s %(levelname)s:%(name)s:%(message)s", level=logging.INFO)
 
@@ -74,7 +77,7 @@ class LiquidSchedule:
         LiquidAPI.add_blocks(self.conf, new_blocks)
         self._load_blocks()
 
-    def _fill(self, slot_config, tag_str, current_mark) -> LiquidBlock:
+    def _fill(self, slot_config, tag_str, current_mark, exclusion_index=None) -> LiquidBlock:
         seq_key = None
         candidate = None
         new_block = None
@@ -89,7 +92,30 @@ class LiquidSchedule:
 
             seq_key = SequenceAPI.make_sequence_key(self.conf, seq_name, tag_str)
         else:
-            candidate = self.catalog.find_candidate(tag_str, timings.HOUR * 23, current_mark)
+            try:
+                candidate = self.catalog.find_candidate(
+                    tag_str, timings.HOUR * 23, current_mark,
+                    exclusion_index=exclusion_index, proposed_start=current_mark
+                )
+            except MatchingContentNotFound:
+                if exclusion_index:
+                    # Exclusion may have blocked everything - retry without it.
+                    # If this also fails it is a genuine content shortage.
+                    try:
+                        candidate = self.catalog.find_candidate(tag_str, timings.HOUR * 23, current_mark)
+                        self._l.warning(
+                            f"[{self.conf['network_name']}] Sibling exclusion blocked all candidates "
+                            f"for tag={tag_str} at {current_mark} - "
+                            f"scheduling without exclusion (overlap unavoidable for this slot)"
+                        )
+                    except MatchingContentNotFound:
+                        self._l.error(
+                            f"[{self.conf['network_name']}] No content available for tag={tag_str} "
+                            f"at {current_mark} even without exclusion - genuine content shortage"
+                        )
+                        raise
+                else:
+                    raise
 
         if candidate:
 
@@ -197,6 +223,129 @@ class LiquidSchedule:
                 return block.content.tag
         return None
 
+    @staticmethod
+    def _get_station_tags(station_conf):
+        """Return the set of all content tags used in a station's schedule config.
+        Tags come from slot definitions, clip_shows keys, and fallback_tag.
+        Used to determine whether two channels can ever schedule the same file.
+        """
+        tags = set()
+        for day in timings.DAYS:
+            for slot in station_conf.get(day, {}).values():
+                if not isinstance(slot, dict):
+                    continue
+                t = slot.get("tags")
+                if isinstance(t, list):
+                    tags.update(t)
+                elif t:
+                    tags.add(t)
+        # clip_shows can be a dict {tag: config} or a legacy list [""] — handle both
+        # filter out empty-string keys that result from legacy/unset clip_show entries
+        cs = station_conf.get("clip_shows", {})
+        if isinstance(cs, dict):
+            tags.update(k for k in cs.keys() if k)
+        ft = station_conf.get("fallback_tag")
+        if ft:
+            tags.add(ft)
+        return tags
+
+    def _build_exclusion_index(self, start_time, end_target):
+        """Build an in-memory exclusion index from sibling channels that share
+        the same content_dir AND have overlapping tags (i.e. they can actually
+        schedule the same files).  Returns {realpath: [(start_time, end_time), ...]}
+        pre-populated from already-scheduled blocks so that the current channel
+        will not pick a movie that is already playing (or about to play) on a
+        sibling channel.
+
+        Using both content_dir AND tag intersection means that channels which
+        share a parent content_dir but use completely different subdirectory tags
+        (e.g. Comedy and Drama both under catalog/movies) are correctly excluded
+        from each other's sibling group — they can never pick the same file.
+
+        The index is also updated in-memory as each new block is scheduled
+        (see _register_exclusion) so sibling protection works even for slots
+        being built in the same run, not just slots from previous runs.
+
+        Sequences bypass find_candidate entirely and are therefore intentionally
+        exempt from exclusion - they always take priority.
+        """
+        exclusion_index = {}
+        try:
+            my_content_dir = os.path.realpath(self.conf.get("content_dir", ""))
+            if not my_content_dir:
+                return exclusion_index
+
+            # Pre-compute tags for every station once to avoid re-iterating
+            # all schedule slots N times (once per station in the comparison).
+            all_stations = StationManager().stations
+            all_station_tags = {
+                s.get("network_name"): LiquidSchedule._get_station_tags(s)
+                for s in all_stations
+            }
+            my_tags = (
+                all_station_tags.get(self.conf["network_name"])
+                or LiquidSchedule._get_station_tags(self.conf)
+            )
+
+            siblings = [
+                s for s in all_stations
+                if s.get("network_type") == "standard"
+                and s.get("network_name") != self.conf["network_name"]
+                and os.path.realpath(s.get("content_dir", "")) == my_content_dir
+                and bool(my_tags & all_station_tags.get(s.get("network_name"), set()))
+            ]
+
+            if not siblings:
+                return exclusion_index
+
+            self._l.info(
+                f"Found {len(siblings)} sibling channel(s) sharing content_dir - "
+                f"building exclusion index for overlap protection"
+            )
+
+            liquid_io = LiquidIO()
+            for sibling in siblings:
+                blocks = liquid_io.query_liquid_blocks(
+                    sibling["network_name"],
+                    str(start_time),
+                    str(end_target),
+                )
+                for block in blocks:
+                    if block.content and not isinstance(block.content, list):
+                        rp = block.content.realpath
+                        if rp:
+                            if rp not in exclusion_index:
+                                exclusion_index[rp] = []
+                            exclusion_index[rp].append((block.start_time, block.end_time))
+
+            total = sum(len(v) for v in exclusion_index.values())
+            self._l.info(
+                f"Exclusion index built: {total} window(s) across "
+                f"{len(exclusion_index)} unique title(s)"
+            )
+        except (sqlite3.Error, OSError) as e:
+            self._l.warning(
+                f"Could not build exclusion index - sibling overlap protection disabled: {e}",
+                exc_info=True,
+            )
+            exclusion_index = {}
+
+        return exclusion_index
+
+    @staticmethod
+    def _register_exclusion(exclusion_index, block):
+        """Register a freshly scheduled block in the exclusion index so that
+        subsequent picks within the same scheduling run respect it.
+        Clip blocks (list content) and off-air blocks are skipped - only
+        single-content feature blocks (i.e. movies) are tracked.
+        """
+        if block and block.content and not isinstance(block.content, list):
+            rp = block.content.realpath
+            if rp:
+                if rp not in exclusion_index:
+                    exclusion_index[rp] = []
+                exclusion_index[rp].append((block.start_time, block.end_time))
+
     def _fluid(self, start_time, end_target):
         # this is the core of the scheduler.
         new_blocks = []
@@ -206,6 +355,9 @@ class LiquidSchedule:
             current_mark = datetime.datetime.now()
 
         forward_buffer = []
+
+        # build exclusion index from sibling channels that share the same content_dir
+        exclusion_index = self._build_exclusion_index(start_time, end_target)
 
         self._l.info(f"Starting to build blocks for {self.conf['network_name']}")
         while current_mark < end_target:
@@ -230,13 +382,13 @@ class LiquidSchedule:
                 if tag_str not in self.conf["clip_shows"]:
                     #print("not clip show")
                     try:
-                        new_block, next_mark = self._fill(slot_config, tag_str, current_mark)
+                        new_block, next_mark = self._fill(slot_config, tag_str, current_mark, exclusion_index=exclusion_index)
                     except ClipShowKickBack as e:
                         new_block, next_mark = self._clip_fill(e.clip_tag, current_mark, slot_config)
                     except MatchingContentNotFound as e:
                         if "fallback_tag" in self.conf:
                             fb_config = {"tags": self.conf["fallback_tag"]}
-                            new_block, next_mark = self._fill(fb_config, fb_config["tags"], current_mark)
+                            new_block, next_mark = self._fill(fb_config, fb_config["tags"], current_mark, exclusion_index=exclusion_index)
                         else:
                             self._l.warning("Content not found, but no fallback_tag specified.")
                             raise e
@@ -270,6 +422,7 @@ class LiquidSchedule:
 
             # here
             new_blocks.append(new_block)
+            self._register_exclusion(exclusion_index, new_block)
             current_mark = next_mark
         self._l.info("Content and reel schedules are completed")
 

--- a/test/test_exclusion.py
+++ b/test/test_exclusion.py
@@ -1,0 +1,726 @@
+"""
+Tests for the cross-channel sibling exclusion logic.
+
+The feature prevents channels that share the same content_dir (e.g. Comedy1,
+Comedy2, Comedy3) from scheduling the same movie at overlapping times — both
+the "exact same start" case and the "starts halfway through" case.
+
+Key pieces under test
+---------------------
+1. Overlap detection math  (inline in find_candidate, tested in isolation)
+2. find_candidate exclusion filtering  (catalog.py)
+3. _register_exclusion static method  (liquid_schedule.py)
+4. _build_exclusion_index method  (liquid_schedule.py)
+
+Running
+-------
+    # without pytest (stdlib only):
+    python3 -m unittest test.test_exclusion -v
+
+    # with pytest:
+    python3 -m pytest test/test_exclusion.py -v
+"""
+
+import sys
+import os
+import datetime
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Stub out heavy / native deps BEFORE any fs42 import so the module-level
+# guard in media_processor.py ("ffmpeg-python not found") does not abort.
+# MagicMock satisfies `hasattr(ffmpeg, 'probe')` automatically.
+# ---------------------------------------------------------------------------
+_ffmpeg_stub = MagicMock()
+_ffmpeg_stub.probe = MagicMock()
+sys.modules.setdefault("ffmpeg", _ffmpeg_stub)
+
+_moviepy_stub = MagicMock()
+sys.modules.setdefault("moviepy", _moviepy_stub)
+sys.modules.setdefault("moviepy.editor", _moviepy_stub)
+
+# ---------------------------------------------------------------------------
+# Safe to import fs42 now
+# ---------------------------------------------------------------------------
+from fs42.catalog_entry import CatalogEntry, MatchingContentNotFound  # noqa: E402
+from fs42.liquid_blocks import LiquidBlock                             # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures
+# ---------------------------------------------------------------------------
+
+# A stable timeline for every test: Mon 1 Jan 2025
+T20 = datetime.datetime(2025, 1, 1, 20, 0, 0)   # 20:00
+T21 = datetime.datetime(2025, 1, 1, 21, 0, 0)   # 21:00
+T22 = datetime.datetime(2025, 1, 1, 22, 0, 0)   # 22:00
+T23 = datetime.datetime(2025, 1, 1, 23, 0, 0)   # 23:00
+
+MOVIE_A = "/content/comedy/movie_a.mp4"
+MOVIE_B = "/content/comedy/movie_b.mp4"
+MOVIE_C = "/content/comedy/movie_c.mp4"
+CONTENT_DIR = "/content"
+
+NINETY_MIN = 90 * 60   # 5400 seconds
+
+
+def _entry(path, duration=NINETY_MIN, count=0):
+    """Build a CatalogEntry without touching the database."""
+    e = CatalogEntry(path, duration, "comedy")
+    e.realpath = os.path.realpath(path)
+    e.count = count
+    e.dbid = 1
+    return e
+
+
+def _block(content, start, end):
+    """Build a minimal mock LiquidBlock."""
+    b = MagicMock(spec=LiquidBlock)
+    b.content = content
+    b.start_time = start
+    b.end_time = end
+    return b
+
+
+def _catalog(entries, network_name="Comedy1"):
+    """Return a ShowCatalog with a hand-built clip_index, bypassing the DB."""
+    from fs42.catalog import ShowCatalog
+    conf = {
+        "network_name": network_name,
+        "network_type": "standard",
+        "content_dir": CONTENT_DIR,
+        "clip_shows": {},
+        "break_strategy": "standard",
+        "break_duration": 120,
+        "commercial_free": True,
+        "bump_dir": "bump",
+        "schedule_increment": 30,
+    }
+    cat = ShowCatalog(conf, load=False)
+    cat.clip_index = {"comedy": list(entries)}
+    return cat
+
+
+# ---------------------------------------------------------------------------
+# 1.  Overlap detection math
+#     The logic lives inline inside find_candidate.  We replicate it here so
+#     it can be exercised exhaustively without requiring a full catalog.
+# ---------------------------------------------------------------------------
+
+class TestOverlapLogic(unittest.TestCase):
+    """Verify the time-window overlap predicate used inside find_candidate."""
+
+    @staticmethod
+    def _overlaps(windows, proposed_start, duration_seconds):
+        proposed_end = proposed_start + datetime.timedelta(seconds=duration_seconds)
+        return any(
+            proposed_start < w_end and w_start < proposed_end
+            for w_start, w_end in windows
+        )
+
+    def test_exact_same_window(self):
+        """Proposed window identical to an existing window → overlap."""
+        self.assertTrue(self._overlaps([(T20, T22)], T20, NINETY_MIN * 2))
+
+    def test_starts_inside_existing_window(self):
+        """We start 1 h into a sibling's 2-h movie → overlap (the half-through case)."""
+        self.assertTrue(self._overlaps([(T20, T22)], T21, NINETY_MIN))
+
+    def test_ends_inside_existing_window(self):
+        """Our movie starts before the sibling's but ends during it → overlap."""
+        self.assertTrue(self._overlaps([(T21, T23)], T20, NINETY_MIN * 2))
+
+    def test_contains_existing_window(self):
+        """Our window completely contains the sibling's window → overlap."""
+        self.assertTrue(self._overlaps([(T21, T22)], T20, 3 * 3600))
+
+    def test_adjacent_before_no_overlap(self):
+        """Our movie ends exactly when the sibling's starts → NOT an overlap."""
+        # us: 20:00 + 2 h → ends 22:00 exactly; sibling: 22:00 – 23:00
+        self.assertFalse(self._overlaps([(T22, T23)], T20, 2 * 3600))
+
+    def test_adjacent_after_no_overlap(self):
+        """Our movie starts exactly when the sibling's ends → NOT an overlap."""
+        # sibling: 20:00 – 21:00; us: starts 21:00 for 2 h
+        self.assertFalse(self._overlaps([(T20, T21)], T21, 2 * 3600))
+
+    def test_completely_before_no_overlap(self):
+        self.assertFalse(self._overlaps([(T22, T23)], T20, NINETY_MIN))
+
+    def test_completely_after_no_overlap(self):
+        self.assertFalse(self._overlaps([(T20, T21)], T22, NINETY_MIN))
+
+    def test_empty_window_list(self):
+        self.assertFalse(self._overlaps([], T20, NINETY_MIN))
+
+    def test_multiple_windows_one_hits(self):
+        windows = [
+            (datetime.datetime(2025, 1, 1, 10, 0), datetime.datetime(2025, 1, 1, 12, 0)),
+            (T20, T22),   # this one overlaps with T21 + 90 min
+        ]
+        self.assertTrue(self._overlaps(windows, T21, NINETY_MIN))
+
+    def test_multiple_windows_none_hit(self):
+        windows = [
+            (datetime.datetime(2025, 1, 1, 10, 0), datetime.datetime(2025, 1, 1, 12, 0)),
+            (datetime.datetime(2025, 1, 1, 14, 0), datetime.datetime(2025, 1, 1, 16, 0)),
+        ]
+        self.assertFalse(self._overlaps(windows, T20, NINETY_MIN))
+
+
+# ---------------------------------------------------------------------------
+# 2.  find_candidate exclusion filtering
+# ---------------------------------------------------------------------------
+
+class TestFindCandidateExclusion(unittest.TestCase):
+
+    def test_no_exclusion_picks_lowest_count(self):
+        """Baseline: no exclusion_index → lowest-count candidate wins."""
+        a = _entry(MOVIE_A, count=2)
+        b = _entry(MOVIE_B, count=0)   # lowest → wins
+        c = _entry(MOVIE_C, count=1)
+        cat = _catalog([a, b, c])
+
+        result = cat.find_candidate("comedy", 99999, T20)
+        self.assertEqual(result.path, MOVIE_B)
+
+    def test_excluded_candidate_skipped(self):
+        """Movie A is on a sibling right now — we must not pick it."""
+        a = _entry(MOVIE_A, count=0)   # would win without exclusion
+        b = _entry(MOVIE_B, count=0)
+        c = _entry(MOVIE_C, count=1)
+        cat = _catalog([a, b, c])
+
+        exclusion_index = {
+            os.path.realpath(MOVIE_A): [(T20, T20 + datetime.timedelta(seconds=NINETY_MIN))]
+        }
+        result = cat.find_candidate(
+            "comedy", 99999, T20,
+            exclusion_index=exclusion_index,
+            proposed_start=T20,
+        )
+        self.assertNotEqual(result.path, MOVIE_A)
+
+    def test_mid_play_overlap_is_blocked(self):
+        """
+        Sibling started Movie A 45 min ago and is still playing.
+        We would launch it at the same wall-clock moment — should be blocked.
+        """
+        a = _entry(MOVIE_A, count=0)
+        b = _entry(MOVIE_B, count=0)
+        cat = _catalog([a, b])
+
+        sibling_start = T20 - datetime.timedelta(minutes=45)
+        sibling_end   = T20 + datetime.timedelta(minutes=45)
+        exclusion_index = {
+            os.path.realpath(MOVIE_A): [(sibling_start, sibling_end)]
+        }
+        result = cat.find_candidate(
+            "comedy", 99999, T20,
+            exclusion_index=exclusion_index,
+            proposed_start=T20,
+        )
+        self.assertNotEqual(result.path, MOVIE_A)
+
+    def test_finished_window_is_allowed(self):
+        """
+        Sibling played Movie A earlier in the day; it has finished.
+        Movie A should be available again (lowest count wins).
+        """
+        a = _entry(MOVIE_A, count=0)   # lowest count
+        b = _entry(MOVIE_B, count=1)
+        cat = _catalog([a, b])
+
+        # sibling played it 14:00 – 16:00; we're scheduling at 20:00
+        past = (datetime.datetime(2025, 1, 1, 14, 0), datetime.datetime(2025, 1, 1, 16, 0))
+        exclusion_index = {os.path.realpath(MOVIE_A): [past]}
+
+        result = cat.find_candidate(
+            "comedy", 99999, T20,
+            exclusion_index=exclusion_index,
+            proposed_start=T20,
+        )
+        self.assertEqual(result.path, MOVIE_A)
+
+    def test_all_candidates_excluded_raises(self):
+        """When every candidate is blocked, MatchingContentNotFound is raised."""
+        entries = [_entry(p) for p in (MOVIE_A, MOVIE_B, MOVIE_C)]
+        cat = _catalog(entries)
+
+        window = (T20, T20 + datetime.timedelta(seconds=NINETY_MIN))
+        exclusion_index = {
+            os.path.realpath(MOVIE_A): [window],
+            os.path.realpath(MOVIE_B): [window],
+            os.path.realpath(MOVIE_C): [window],
+        }
+        with self.assertRaises(MatchingContentNotFound):
+            cat.find_candidate(
+                "comedy", 99999, T20,
+                exclusion_index=exclusion_index,
+                proposed_start=T20,
+            )
+
+    def test_none_realpath_is_not_excluded(self):
+        """
+        If a CatalogEntry has no realpath (shouldn't happen in practice but
+        could on an edge-case entry), it is not excluded — it competes normally.
+        """
+        a = _entry(MOVIE_A, count=0)
+        a.realpath = None   # simulate missing realpath
+        cat = _catalog([a])
+
+        # Even with a matching key in the exclusion index, realpath=None means
+        # the guard is skipped and the entry is a valid candidate.
+        exclusion_index = {None: [(T20, T22)]}  # key is None — won't match guard
+        result = cat.find_candidate(
+            "comedy", 99999, T20,
+            exclusion_index=exclusion_index,
+            proposed_start=T20,
+        )
+        self.assertEqual(result.path, MOVIE_A)
+
+    def test_no_proposed_start_disables_check(self):
+        """
+        exclusion_index without proposed_start → check is bypassed entirely.
+        Backwards-compatible: callers that don't pass proposed_start are unaffected.
+        """
+        a = _entry(MOVIE_A, count=0)
+        cat = _catalog([a])
+
+        # Even though the exclusion_index marks the window, no proposed_start
+        # means we skip the check.
+        exclusion_index = {
+            os.path.realpath(MOVIE_A): [(T20, T22)]
+        }
+        result = cat.find_candidate(
+            "comedy", 99999, T20,
+            exclusion_index=exclusion_index,
+            # proposed_start intentionally omitted
+        )
+        self.assertEqual(result.path, MOVIE_A)
+
+
+# ---------------------------------------------------------------------------
+# 3.  _register_exclusion  (static method — no mocking required)
+# ---------------------------------------------------------------------------
+
+class TestRegisterExclusion(unittest.TestCase):
+
+    @staticmethod
+    def _register():
+        from fs42.liquid_schedule import LiquidSchedule
+        return LiquidSchedule._register_exclusion
+
+    def test_adds_new_key(self):
+        reg = self._register()
+        index = {}
+        content = MagicMock()
+        content.realpath = MOVIE_A
+        block = MagicMock()
+        block.content = content
+        block.start_time = T20
+        block.end_time = T22
+
+        reg(index, block)
+
+        self.assertIn(MOVIE_A, index)
+        self.assertEqual(index[MOVIE_A], [(T20, T22)])
+
+    def test_appends_second_window_for_same_path(self):
+        reg = self._register()
+        index = {MOVIE_A: [(T20, T21)]}
+        content = MagicMock()
+        content.realpath = MOVIE_A
+        block = MagicMock()
+        block.content = content
+        block.start_time = T22
+        block.end_time = T23
+
+        reg(index, block)
+
+        self.assertEqual(len(index[MOVIE_A]), 2)
+        self.assertIn((T22, T23), index[MOVIE_A])
+
+    def test_list_content_ignored(self):
+        """Clip blocks hold a list of entries — they must not be indexed."""
+        reg = self._register()
+        index = {}
+        block = MagicMock()
+        block.content = [MagicMock(), MagicMock()]
+
+        reg(index, block)
+
+        self.assertEqual(index, {})
+
+    def test_none_content_ignored(self):
+        reg = self._register()
+        index = {}
+        block = MagicMock()
+        block.content = None
+
+        reg(index, block)
+
+        self.assertEqual(index, {})
+
+    def test_none_realpath_ignored(self):
+        reg = self._register()
+        index = {}
+        content = MagicMock()
+        content.realpath = None
+        block = MagicMock()
+        block.content = content
+
+        reg(index, block)
+
+        self.assertEqual(index, {})
+
+    def test_index_not_mutated_for_off_air(self):
+        """Off-air blocks have no content — index stays empty."""
+        reg = self._register()
+        index = {}
+        block = MagicMock()
+        block.content = None
+
+        reg(index, block)
+
+        self.assertEqual(index, {})
+
+
+# ---------------------------------------------------------------------------
+# 4.  _build_exclusion_index  (StationManager + LiquidIO mocked)
+# ---------------------------------------------------------------------------
+
+class TestBuildExclusionIndex(unittest.TestCase):
+
+    def _make_schedule(self):
+        """Return a bare LiquidSchedule instance, bypassing DB and file I/O."""
+        conf = {
+            "network_name": "Comedy1",
+            "network_type": "standard",
+            "content_dir": CONTENT_DIR,
+            "clip_shows": {},
+            "break_strategy": "standard",
+            "break_duration": 120,
+            "commercial_free": True,
+            "bump_dir": "bump",
+            "schedule_increment": 30,
+            "monday": {"0": {"tags": "comedy"}},
+        }
+        with patch("fs42.liquid_schedule.StationManager"), \
+             patch("fs42.liquid_schedule.LiquidIO"), \
+             patch("fs42.liquid_schedule.LiquidAPI"), \
+             patch("fs42.catalog.CatalogAPI"):
+            from fs42.liquid_schedule import LiquidSchedule
+            sched = LiquidSchedule.__new__(LiquidSchedule)
+            sched.conf = conf
+            import logging
+            sched._l = logging.getLogger("test-exclusion")
+        return sched
+
+    def _sibling_conf(self, name="Comedy2", content_dir=CONTENT_DIR, tag="comedy"):
+        return {
+            "network_name": name,
+            "network_type": "standard",
+            "content_dir": content_dir,
+            "monday": {"0": {"tags": tag}},
+        }
+
+    # ---- helpers shared across sub-tests ----
+
+    def test_no_siblings_returns_empty_dict(self):
+        sched = self._make_schedule()
+        stations = [
+            {"network_name": "Comedy1", "network_type": "standard", "content_dir": CONTENT_DIR},
+        ]
+        with patch("fs42.liquid_schedule.StationManager") as MockSM, \
+             patch("fs42.liquid_schedule.LiquidIO") as MockIO:
+            MockSM.return_value.stations = stations
+
+            result = sched._build_exclusion_index(T20, T22)
+
+        self.assertEqual(result, {})
+        MockIO.return_value.query_liquid_blocks.assert_not_called()
+
+    def test_sibling_blocks_populate_index(self):
+        sched = self._make_schedule()
+        stations = [
+            {"network_name": "Comedy1", "network_type": "standard", "content_dir": CONTENT_DIR},
+            self._sibling_conf("Comedy2"),
+        ]
+        rp = os.path.realpath(MOVIE_A)
+        content = MagicMock()
+        content.realpath = rp
+        mock_block = _block(content, T20, T22)
+
+        with patch("fs42.liquid_schedule.StationManager") as MockSM, \
+             patch("fs42.liquid_schedule.LiquidIO") as MockIO:
+            MockSM.return_value.stations = stations
+            MockIO.return_value.query_liquid_blocks.return_value = [mock_block]
+
+            result = sched._build_exclusion_index(T20, T22)
+
+        self.assertIn(rp, result)
+        self.assertEqual(result[rp], [(T20, T22)])
+
+    def test_multiple_siblings_all_queried(self):
+        sched = self._make_schedule()
+        stations = [
+            {"network_name": "Comedy1", "network_type": "standard", "content_dir": CONTENT_DIR},
+            self._sibling_conf("Comedy2"),
+            self._sibling_conf("Comedy3"),
+            self._sibling_conf("Comedy4"),
+        ]
+        with patch("fs42.liquid_schedule.StationManager") as MockSM, \
+             patch("fs42.liquid_schedule.LiquidIO") as MockIO:
+            MockSM.return_value.stations = stations
+            MockIO.return_value.query_liquid_blocks.return_value = []
+
+            sched._build_exclusion_index(T20, T22)
+
+        # Should have been called once per sibling (3 times)
+        self.assertEqual(MockIO.return_value.query_liquid_blocks.call_count, 3)
+
+    def test_different_content_dir_not_a_sibling(self):
+        sched = self._make_schedule()
+        stations = [
+            {"network_name": "Comedy1", "network_type": "standard", "content_dir": CONTENT_DIR},
+            self._sibling_conf("Sports1", content_dir="/other/content"),
+        ]
+        with patch("fs42.liquid_schedule.StationManager") as MockSM, \
+             patch("fs42.liquid_schedule.LiquidIO") as MockIO:
+            MockSM.return_value.stations = stations
+
+            result = sched._build_exclusion_index(T20, T22)
+
+        self.assertEqual(result, {})
+        MockIO.return_value.query_liquid_blocks.assert_not_called()
+
+    def test_same_content_dir_different_tags_not_a_sibling(self):
+        """Drama channel shares content_dir with Comedy but uses a different tag.
+        It can never schedule comedy files so it must not be treated as a sibling."""
+        sched = self._make_schedule()  # Comedy1, tag=comedy
+
+        # Drama channel: same content_dir, different tag
+        drama_conf = {
+            "network_name": "Drama1",
+            "network_type": "standard",
+            "content_dir": CONTENT_DIR,
+            "monday": {"0": {"tags": "drama"}},
+        }
+        stations = [
+            {"network_name": "Comedy1", "network_type": "standard",
+             "content_dir": CONTENT_DIR, "monday": {"0": {"tags": "comedy"}}},
+            drama_conf,
+        ]
+        with patch("fs42.liquid_schedule.StationManager") as MockSM, \
+             patch("fs42.liquid_schedule.LiquidIO") as MockIO:
+            MockSM.return_value.stations = stations
+
+            result = sched._build_exclusion_index(T20, T22)
+
+        self.assertEqual(result, {})
+        MockIO.return_value.query_liquid_blocks.assert_not_called()
+
+    def test_same_content_dir_same_tag_is_sibling(self):
+        """Two comedy channels sharing both content_dir and tag are genuine siblings."""
+        sched = self._make_schedule()  # Comedy1, tag=comedy
+
+        comedy2_conf = {
+            "network_name": "Comedy2",
+            "network_type": "standard",
+            "content_dir": CONTENT_DIR,
+            "monday": {"0": {"tags": "comedy"}},
+        }
+        stations = [
+            {"network_name": "Comedy1", "network_type": "standard",
+             "content_dir": CONTENT_DIR, "monday": {"0": {"tags": "comedy"}}},
+            comedy2_conf,
+        ]
+        rp = os.path.realpath(MOVIE_A)
+        content = MagicMock()
+        content.realpath = rp
+        mock_block = _block(content, T20, T22)
+
+        with patch("fs42.liquid_schedule.StationManager") as MockSM, \
+             patch("fs42.liquid_schedule.LiquidIO") as MockIO:
+            MockSM.return_value.stations = stations
+            MockIO.return_value.query_liquid_blocks.return_value = [mock_block]
+
+            result = sched._build_exclusion_index(T20, T22)
+
+        self.assertIn(rp, result)
+
+    def test_list_content_blocks_skipped(self):
+        """Clip blocks (list content) must not appear in the exclusion index."""
+        sched = self._make_schedule()
+        stations = [
+            {"network_name": "Comedy1", "network_type": "standard", "content_dir": CONTENT_DIR},
+            self._sibling_conf("Comedy2"),
+        ]
+        list_block = _block([MagicMock(), MagicMock()], T20, T22)  # clip show
+
+        with patch("fs42.liquid_schedule.StationManager") as MockSM, \
+             patch("fs42.liquid_schedule.LiquidIO") as MockIO:
+            MockSM.return_value.stations = stations
+            MockIO.return_value.query_liquid_blocks.return_value = [list_block]
+
+            result = sched._build_exclusion_index(T20, T22)
+
+        self.assertEqual(result, {})
+
+    def test_exception_returns_empty_gracefully(self):
+        """DB or IO errors during index build degrade gracefully — the scheduler
+        continues without exclusion protection rather than crashing.  Logic errors
+        (TypeError, AttributeError etc.) are NOT caught and will still propagate."""
+        sched = self._make_schedule()
+
+        with patch("fs42.liquid_schedule.StationManager") as MockSM:
+            import sqlite3
+            MockSM.side_effect = sqlite3.OperationalError("unable to open database")
+            result = sched._build_exclusion_index(T20, T22)
+
+        self.assertEqual(result, {})
+
+    def test_query_called_with_correct_time_range(self):
+        """Verify query_liquid_blocks receives space-separated datetime strings
+        matching SQLite storage format (not isoformat T-separator strings, which
+        would break same-day comparisons due to ASCII ordering: ' ' < 'T')."""
+        sched = self._make_schedule()
+        stations = [
+            {"network_name": "Comedy1", "network_type": "standard", "content_dir": CONTENT_DIR},
+            self._sibling_conf("Comedy2"),
+        ]
+        with patch("fs42.liquid_schedule.StationManager") as MockSM, \
+             patch("fs42.liquid_schedule.LiquidIO") as MockIO:
+            MockSM.return_value.stations = stations
+            MockIO.return_value.query_liquid_blocks.return_value = []
+
+            sched._build_exclusion_index(T20, T22)
+
+        MockIO.return_value.query_liquid_blocks.assert_called_once_with(
+            "Comedy2",
+            str(T20),
+            str(T22),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5.  _fill graceful degradation  (exclusion exhausts candidates → retry)
+# ---------------------------------------------------------------------------
+
+class TestFillGracefulDegradation(unittest.TestCase):
+    """When sibling exclusion blocks every candidate, _fill must retry without
+    the exclusion index, log a WARNING, and return a block rather than raising.
+    Only a genuine content shortage (fails even without exclusion) should
+    propagate the exception."""
+
+    def _make_sched(self):
+        """LiquidSchedule with a mocked catalog, bypassing DB and file I/O."""
+        with patch("fs42.liquid_schedule.StationManager"), \
+             patch("fs42.liquid_schedule.LiquidIO"), \
+             patch("fs42.liquid_schedule.LiquidAPI"), \
+             patch("fs42.catalog.CatalogAPI"):
+            from fs42.liquid_schedule import LiquidSchedule
+            sched = LiquidSchedule.__new__(LiquidSchedule)
+            sched.conf = {
+                "network_name": "Comedy1",
+                "break_strategy": "standard",
+                "schedule_increment": 30,
+                "clip_shows": {},
+                "content_dir": CONTENT_DIR,
+                "tag_overrides": {},
+            }
+            import logging
+            sched._l = logging.getLogger("test-fill")
+        sched.catalog = MagicMock()
+        return sched
+
+    def _slot(self):
+        return {"tags": "comedy"}
+
+    def test_exclusion_fallback_returns_block_and_logs_warning(self):
+        """
+        First find_candidate call (with exclusion) raises MatchingContentNotFound.
+        Second call (without exclusion) succeeds.  _fill must:
+          - return a valid (block, next_mark) tuple
+          - log a WARNING so operators know an overlap was unavoidable
+          - call find_candidate exactly twice
+        """
+        from fs42.catalog_entry import MatchingContentNotFound
+        from fs42.liquid_schedule import LiquidSchedule
+
+        sched = self._make_sched()
+        candidate = MagicMock()
+        candidate.duration = NINETY_MIN
+        candidate.title = "Test Movie"
+        candidate.path = MOVIE_A
+        candidate.realpath = os.path.realpath(MOVIE_A)
+
+        sched.catalog.find_candidate.side_effect = [
+            MatchingContentNotFound("all blocked by exclusion"),
+            candidate,
+        ]
+
+        exclusion_index = {os.path.realpath(MOVIE_A): [(T20, T22)]}
+
+        with patch("fs42.liquid_schedule.PathQuery") as MockPQ, \
+             patch.object(sched, "_break_info", return_value=(
+                 {"start_bump": None, "end_bump": None, "bump_dir": None,
+                  "commercial_dir": None, "break_strategy": None, "increment": None},
+                 "standard", 30
+             )):
+            MockPQ.match_any_from_base.return_value = None
+            with self.assertLogs("test-fill", level="WARNING") as log_ctx:
+                block, next_mark = sched._fill(self._slot(), "comedy", T20,
+                                               exclusion_index=exclusion_index)
+
+        self.assertIsNotNone(block)
+        self.assertIsNotNone(next_mark)
+        # Retried twice: first with exclusion, then without
+        self.assertEqual(sched.catalog.find_candidate.call_count, 2)
+        first_call_kwargs = sched.catalog.find_candidate.call_args_list[0][1]
+        self.assertIsNotNone(first_call_kwargs.get("exclusion_index"))
+        # Warning must be present in logs
+        self.assertTrue(
+            any("exclusion" in m.lower() or "overlap unavoidable" in m.lower()
+                for m in log_ctx.output)
+        )
+
+    def test_genuine_content_shortage_propagates(self):
+        """
+        When find_candidate raises even WITHOUT the exclusion index, it is a
+        genuine content shortage (not an exclusion side-effect).  The exception
+        must propagate so the caller can decide how to handle it.
+        """
+        from fs42.catalog_entry import MatchingContentNotFound
+        sched = self._make_sched()
+        # Both calls fail — no content exists at all
+        sched.catalog.find_candidate.side_effect = MatchingContentNotFound("no content")
+
+        exclusion_index = {os.path.realpath(MOVIE_A): [(T20, T22)]}
+
+        with patch("fs42.liquid_schedule.PathQuery"):
+            with self.assertRaises(MatchingContentNotFound):
+                sched._fill(self._slot(), "comedy", T20,
+                            exclusion_index=exclusion_index)
+
+    def test_no_exclusion_shortage_propagates_immediately(self):
+        """
+        When no exclusion_index is active and content is not found, the exception
+        propagates on the first call without any retry — there is nothing to retry.
+        """
+        from fs42.catalog_entry import MatchingContentNotFound
+        sched = self._make_sched()
+        sched.catalog.find_candidate.side_effect = MatchingContentNotFound("no content")
+
+        with patch("fs42.liquid_schedule.PathQuery"):
+            with self.assertRaises(MatchingContentNotFound):
+                sched._fill(self._slot(), "comedy", T20)  # no exclusion_index
+
+        # Called only once — no retry when there was no exclusion active
+        self.assertEqual(sched.catalog.find_candidate.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

When running multiple movie channels that draw from the same content pool (e.g. Comedy 1, 2, 3, 4 all pointing to `catalog/movies/comedy`), the scheduler would regularly air the same movie simultaneously on two or more channels, or start a movie on one channel while it was already halfway through on another. This is particularly noticeable with dedicated genre channels sharing a parent `content_dir`.

The root cause: each channel's `LiquidSchedule` is built independently with no awareness of what sibling channels are scheduling. The first channel picks freely; later channels have no way to avoid the same picks.

## Solution

Before building each channel's schedule, query the DB for already-scheduled blocks on sibling channels and build an in-memory exclusion index `{realpath: [(start_time, end_time), ...]}`.

`find_candidate` skips any candidate whose file is already playing on a sibling channel in an overlapping time window this handles both exact same-start-time collisions and the "starts halfway through" case.

The index is also updated in-memory as new blocks are picked within the same run, so channels built later in the sequence have full protection.

**Sibling detection** uses both `content_dir` AND schedule tag intersection. Comedy and Drama channels that share `catalog/movies` are correctly not treated as siblings  they use different subdirectory tags and can never schedule the same file. No config changes required.

**Sequences** bypass `find_candidate` entirely and are intentionally exempt  they always take priority.

**Graceful degradation:** if exclusion exhausts all candidates (content pool too small for the number of channels in a given window), the scheduler logs a `WARNING` and falls back to scheduling without exclusion for that slot rather than crashing.

## Bugs fixed along the way

These were discovered during testing and are independently valuable:

**Empty-tag catalog entries:** `commercial_dir: ""` called `_scan_directory("")` which walked the entire `content_dir` with a blank tag, creating a duplicate catalog entry for every file. This doubled catalog size and corrupted tag-based sibling detection.

**Legacy `clip_shows` empty key:** the processed form of an unset `clip_shows` value is `{"": {...}}`. Iterating its keys added `""` to every channel's tag set, making every channel a false sibling of every other.

**`isoformat()` vs SQLite datetime format:** `datetime.isoformat()` produces `"2026-04-18T00:00:00"` (T separator) but SQLite stores datetimes with a space: `"2026-04-18 14:05:32"`. ASCII comparison treats `' '` (32) < `'T'` (84), so `end_time > '2026-04-18T00:00:00'` evaluated `FALSE` for every block on the same calendar day as the build start. The entire first day of every sibling's schedule was invisible to the exclusion index. Fixed by using `str(dt)` which matches SQLite's storage format.

**`FluidBuilder.scan_file_cache` redundant scans:** with 12 stations sharing `catalog/movies`, the full directory walk ran 12 times per rebuild (~5 min vs ~44s with a warm cache). Deduplicated within a process run via a class-level set. A `clear_fluid_cache()` classmethod is exposed and called by the web API rebuild endpoint so long-running server processes don't skip rescans on subsequent rebuild requests.

## Note on `_fluid_cache_scanned`

The deduplication uses a mutable class variable for process-scoped state. Happy to move this into the rebuild loop in `station_42.py` or use a different pattern if preferred.

## Tests

36 unit tests in `test/test_exclusion.py` covering overlap detection math, `find_candidate` exclusion filtering, `_register_exclusion`, `_build_exclusion_index` (including tag-aware sibling detection), and `_fill` graceful degradation.

Run without any external dependencies:

```
python3 -m unittest test.test_exclusion -v
```
