### PR TITLE
Add support for date-specific schedule overrides via date_overrides

### DIFF
--- a/fs42/catalog.py
+++ b/fs42/catalog.py
@@ -184,6 +184,31 @@ class ShowCatalog:
             if "end_bump" in override:
                 end_bumps[override["start_bump"]] = True
 
+        # check for date override tags
+        date_overrides = self.config.get("date_overrides", {})
+        for override_slots in date_overrides.values():
+            for slot_key in override_slots:
+                slot = override_slots[slot_key]
+
+                if not isinstance(slot, dict):
+                    continue
+
+                if "tags" in slot:
+                    if type(slot["tags"]) is list:
+                        for tag in slot["tags"]:
+                            tags[tag] = True
+                    else:
+                        tags[slot["tags"]] = True
+
+                if "bump_dir" in slot:
+                    bump_overrides[slot["bump_dir"]] = True
+                if "commercial_dir" in slot:
+                    commercial_overrides[slot["commercial_dir"]] = True
+                if "start_bump" in slot:
+                    start_bumps[slot["start_bump"]] = True
+                if "end_bump" in slot:
+                    end_bumps[slot["end_bump"]] = True
+
         # check for fallback tag
         if "fallback_tag" in self.config:
             tags[self.config["fallback_tag"]] = True

--- a/fs42/config_processor.py
+++ b/fs42/config_processor.py
@@ -10,12 +10,16 @@ class ConfigurationError(Exception):
 class ConfigProcessor:
     @staticmethod
     def preprocess(conf):
+        # first, fill in templates
         processed = ConfigProcessor._process_templates(conf)
         processed = ConfigProcessor._process_strategy(processed)
         processed = ConfigProcessor._process_date_overrides(processed)
         return processed
 
     @staticmethod
+    # validate that this looks like a "Month Day" string (e.g. "December 25")
+    # we use datetime here instead of RangeHint to avoid a circular import
+    # if it's invalid, it just won't ever match and will fall back to weekday scheduling
     def _valid_date_key(date_key):
         try:
             datetime.strptime(date_key.strip(), "%B %d")
@@ -25,11 +29,13 @@ class ConfigProcessor:
 
     @staticmethod
     def _process_templates(conf):
+        # first, see if there are templates
         if "day_templates" not in conf:
             return conf
 
         templates = conf["day_templates"]
 
+        # now, go through each day:
         for day_key in timings.DAYS:
             if day_key not in conf:
                 raise ConfigurationError(
@@ -37,11 +43,13 @@ class ConfigProcessor:
                 )
 
             if isinstance(conf[day_key], str):
+                # found a potential reference, so see if it exists
                 ref_key = conf[day_key]
                 if ref_key not in templates:
                     raise ConfigurationError(
                         f"Schedule for {conf['network_name']} references a template for {ref_key} on {day_key}, but that template doesn't exist."
                     )
+                # then just inline it :)
 
                 conf[day_key] = templates[ref_key]
 

--- a/fs42/config_processor.py
+++ b/fs42/config_processor.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fs42 import timings
 
 
@@ -8,20 +10,26 @@ class ConfigurationError(Exception):
 class ConfigProcessor:
     @staticmethod
     def preprocess(conf):
-        # first, fill in templates
         processed = ConfigProcessor._process_templates(conf)
         processed = ConfigProcessor._process_strategy(processed)
+        processed = ConfigProcessor._process_date_overrides(processed)
         return processed
 
     @staticmethod
+    def _valid_date_key(date_key):
+        try:
+            datetime.strptime(date_key.strip(), "%B %d")
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
     def _process_templates(conf):
-        # first, see if there are templates
         if "day_templates" not in conf:
             return conf
 
         templates = conf["day_templates"]
 
-        # now, go through each day:
         for day_key in timings.DAYS:
             if day_key not in conf:
                 raise ConfigurationError(
@@ -29,17 +37,58 @@ class ConfigProcessor:
                 )
 
             if isinstance(conf[day_key], str):
-                # found a potential refernce, so see if it exists
                 ref_key = conf[day_key]
                 if ref_key not in templates:
                     raise ConfigurationError(
-                        f"Schedule for {conf['network_name']} references a templates for {ref_key} on {day_key}, but that template doesn't exist."
+                        f"Schedule for {conf['network_name']} references a template for {ref_key} on {day_key}, but that template doesn't exist."
                     )
-                # then just inline it :)
+
                 conf[day_key] = templates[ref_key]
 
         return conf
 
+    @staticmethod
+    def _process_date_overrides(conf):
+        if "date_overrides" not in conf:
+            return conf
+
+        overrides = conf["date_overrides"]
+
+        if not isinstance(overrides, dict):
+            raise ConfigurationError(
+                f"date_overrides for {conf['network_name']} must be an object mapping dates to slot definitions."
+            )
+
+        processed_overrides = {}
+
+        for date_key, override_value in overrides.items():
+            if not ConfigProcessor._valid_date_key(date_key):
+                raise ConfigurationError(
+                    f"date_overrides entry '{date_key}' for {conf['network_name']} is not a valid month/day like 'December 25'."
+                )
+
+            if isinstance(override_value, str):
+                template_key = override_value
+
+                if "day_templates" not in conf or template_key not in conf["day_templates"]:
+                    raise ConfigurationError(
+                        f"date_overrides entry '{date_key}' for {conf['network_name']} references template '{template_key}', but that template doesn't exist."
+                    )
+
+                processed_overrides[date_key] = conf["day_templates"][template_key]
+
+            elif isinstance(override_value, dict):
+                processed_overrides[date_key] = override_value
+
+            else:
+                raise ConfigurationError(
+                    f"date_overrides entry '{date_key}' for {conf['network_name']} must be either a day template reference or an object of hourly slots."
+                )
+
+        conf["date_overrides"] = processed_overrides
+        return conf
+
+    @staticmethod
     def _process_strategy(conf):
         if "slot_overrides" not in conf:
             return conf
@@ -79,7 +128,7 @@ class ConfigProcessor:
                             )
 
                         conf[day_key][hour_key][to_override] = or_def[to_override]
+
                     del conf[day_key][hour_key]["overrides"]
 
         return conf
-

--- a/fs42/slot_reader.py
+++ b/fs42/slot_reader.py
@@ -41,12 +41,12 @@ class SlotReader:
                     # first, figure out what our segments are
                     num_tags = len(tags)
                     # get the duration of the segmentations in minutes
-                    segment_duration = math.floor(60 / num_tags)
+                    segment_duration = math.floor(60/num_tags)
                     # figure out what segment we are in
-                    current_segment = math.floor(when.minute / segment_duration)
+                    current_segment = math.floor(when.minute/segment_duration)
                     # make sure its not too long
                     if current_segment >= num_tags:
-                        current_segment = num_tags - 1
+                        current_segment = num_tags-1
 
                     return tags[current_segment]
             else:

--- a/fs42/slot_reader.py
+++ b/fs42/slot_reader.py
@@ -38,10 +38,13 @@ class SlotReader:
                 if is_random:
                     response = random.choice(tags)
                 else:
+                    # first, figure out what our segments are
                     num_tags = len(tags)
+                    # get the duration of the segmentations in minutes
                     segment_duration = math.floor(60 / num_tags)
+                    # figure out what segment we are in
                     current_segment = math.floor(when.minute / segment_duration)
-
+                    # make sure its not too long
                     if current_segment >= num_tags:
                         current_segment = num_tags - 1
 
@@ -53,11 +56,7 @@ class SlotReader:
 
     @staticmethod
     def _date_key_matches(date_key, when: datetime):
-        """
-        Match date_overrides keys like:
-            "April 23"
-            "april 23"
-        """
+        # match date_overrides keys like "April 23" (case-insensitive)
         try:
             parsed = datetime.strptime(date_key.strip(), "%B %d")
             return parsed.month == when.month and parsed.day == when.day
@@ -79,7 +78,7 @@ class SlotReader:
 
     def get_slot(conf, when: datetime):
         slot_number = str(when.hour)
-
+        # check for exact date override first, then fall back to weekday schedule
         date_override = SlotReader._get_date_override(conf, when)
         if date_override and slot_number in date_override:
             return date_override[slot_number]
@@ -94,7 +93,7 @@ class SlotReader:
 
     @staticmethod
     def smooth_tags(conf):
-        # this function smooths tags through slot boundaries, so if not specified will use previous slots tag.
+        # this function smooths tags through slot boundaries - so if not specified will use previous slots tag.
         last_tag = None
         smoothed = copy.deepcopy(conf)
         for day_index in timings.DAYS:

--- a/fs42/slot_reader.py
+++ b/fs42/slot_reader.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 import copy
-
 import random
 import math
+
 from fs42 import timings
+
 
 class SlotReader:
     @staticmethod
@@ -37,24 +38,53 @@ class SlotReader:
                 if is_random:
                     response = random.choice(tags)
                 else:
-                    # first, figure out what our segments are
                     num_tags = len(tags)
-                    # get the duration of the segmentations in minutes
-                    segment_duration = math.floor(60/num_tags)
-                    # figure out what segment we are in
-                    current_segment = math.floor(when.minute/segment_duration)
-                    # make sure its not too long
+                    segment_duration = math.floor(60 / num_tags)
+                    current_segment = math.floor(when.minute / segment_duration)
+
                     if current_segment >= num_tags:
-                        current_segment = num_tags-1
+                        current_segment = num_tags - 1
+
                     return tags[current_segment]
             else:
                 response = tags
 
         return response
 
+    @staticmethod
+    def _date_key_matches(date_key, when: datetime):
+        """
+        Match date_overrides keys like:
+            "April 23"
+            "april 23"
+        """
+        try:
+            parsed = datetime.strptime(date_key.strip(), "%B %d")
+            return parsed.month == when.month and parsed.day == when.day
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _get_date_override(conf, when: datetime):
+        overrides = conf.get("date_overrides", {})
+
+        if not isinstance(overrides, dict):
+            return None
+
+        for date_key, override_conf in overrides.items():
+            if SlotReader._date_key_matches(date_key, when):
+                return override_conf
+
+        return None
+
     def get_slot(conf, when: datetime):
-        day_str = timings.DAYS[when.weekday()]
         slot_number = str(when.hour)
+
+        date_override = SlotReader._get_date_override(conf, when)
+        if date_override and slot_number in date_override:
+            return date_override[slot_number]
+
+        day_str = timings.DAYS[when.weekday()]
         response = None
         if day_str in conf:
             if slot_number in conf[day_str]:
@@ -64,7 +94,7 @@ class SlotReader:
 
     @staticmethod
     def smooth_tags(conf):
-        # this function smooths tags through slot boundaries - so if not specified will use previous slots tag.
+        # this function smooths tags through slot boundaries, so if not specified will use previous slots tag.
         last_tag = None
         smoothed = copy.deepcopy(conf)
         for day_index in timings.DAYS:

--- a/fs42/station_config_schema.json
+++ b/fs42/station_config_schema.json
@@ -191,6 +191,28 @@
             }
           }
         },
+        "date_overrides": {
+          "type": "object",
+          "description": "Optional exact-date schedule overrides keyed by month/day like 'December 25'. These take precedence over weekday schedules for matching dates.",
+          "propertyNames": {
+            "pattern": "^[A-Z][a-z]+ [0-3]?[0-9]$"
+          },
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "Reference to a day template"
+              },
+              {
+                "type": "object",
+                "description": "Exact-date schedule with hour slots",
+                "additionalProperties": {
+                  "$ref": "#/$defs/timeSlotConfig"
+                }
+              }
+            ]
+          }
+        },
         "monday": {
           "oneOf": [
             {


### PR DESCRIPTION
## Date-Specific Schedule Overrides (`date_overrides`)

This PR introduces a new optional configuration field, `date_overrides`, which allows a station to override its normal weekday schedule on specific calendar dates.

The goal is to support creating real world programming patterns such as holiday marathons, one-off events, and full-day takeovers easily when creating the standard schedule.

---

## Schema

A new optional field is added under `station_conf` called `date_overrides`. This field is an object where each key is a calendar date written as a string in the format `"Month Day"` (for example, `"December 25"` or `"April 23"`).

Each value can be either a string referencing a `day_template`, or an object that defines a schedule using the exact same structure as a normal weekday (`monday`, `tuesday`, etc.). This means no new scheduling syntax is introduced, the override just reuses the existing hour-based slots structure.

For example, a template-based override looks like this:

```json
"day_templates": {
  "christmas_day": {
    "0": { "tags": "christmas_movie" },
    "1": { "tags": "christmas_movie" }
  }
},
"date_overrides": {
  "December 25": "christmas_day"
}
```

Or an override can be defined without using templates at all:

```json
"date_overrides": {
  "December 25": {
    "0": { "tags": "christmas_movie" },
    "1": { "tags": "christmas_movie" },
    "2": { "tags": "christmas_movie" },
    "3": { "event": "signoff" }
  }
}
```

Because the structure is identical to weekday schedules, it is also possible to partially override a day by only defining specific hours. Any hours not specified in the override will fall back to the normal weekday schedule. For example:

```json
"date_overrides": {
  "April 23": {
    "20": { "tags": "wwf" },
    "21": { "tags": "wcw" }
  }
}
```

In this case, only 8PM and 9PM are overridden on April 23, and the rest of the day behaves normally.

---

## Scheduling Behavior

When building a schedule, the system first checks whether the current date matches any entry in `date_overrides`. If a match is found, it then checks whether the current hour exists within that override. If so, that slot is used. If the hour is not defined in the override, the scheduler falls back to the standard weekday schedule for that hour.

If no matching date is found, the system behaves exactly as it did before and uses the weekday schedule.

So, basically, exact date overrides take priority, and weekday scheduling remains the default fallback.

---

## Implementation Details

This change touches four files, and each modification is additive.

In `fs42/station_config_schema.json`, a new optional `date_overrides` field is added. It accepts either a string (from a day_template) or an object (hourly schedule identical to weekday definitions). No existing schema fields are modified.

In `fs42/config_processor.py`, a new step `_process_date_overrides` is added. This validates that each date key conforms to the `"Month Day"` format using `datetime.strptime`, resolves template refernces into inline schedules, and normalizes the data so it can be used by the scheduler. Existing template and strategy processing logic remains unchanged.

In `fs42/slot_reader.py`, the scheduling logic is extended to check for a matching date override before falling back to the weekday schedule. A small helper function is introduced to match `"Month Day"` strings against the current date. I had to do this instead of just importing `RangeHint` in order to prevent circular imports.

In `fs42/catalog.py`, the catalog builder is extended to include tags that appear only in `date_overrides`. Without this change, any content that is only referenced in a date override (and not in the weekly schedule) would never be discovered during catalog rebuild.

---

## Backward Compatibility

This feature is fully backward compatible. No existing configuration files require any changes, and no behavior is altered unless `date_overrides` is explicitly defined. Weekday scheduling, templates, and all existing configuration patterns continue to function exactly as before.

All changes are additive and isolated to the new feature.

---

## Use Cases

This enables more realistic broadcast programming patterns, including full-day holiday marathons such as December 25 programming blocks, one-off special events, and partial-day takeovers layered on top of existing schedules. It also allows content to exist entirely outside the normal weekly rotation while still being properly indexed and scheduled.

---

## Testing

This was tested locally with full-day overrides, partial-day overrides, template-based overrides, and inline schedules. In all cases, correct fallback behavior was verified and catalog rebuilds successfully included tags used only in `date_overrides`.

---

## Known Issues

There is currently no strict enforcement preventing a user from defining an invalid date such as `"April 56"` in `date_overrides`.

If an invalid date is provided, it will simply never match any real calendar date during scheduling. As a result, the override will never be used, and the system will fall back to the normal weekday schedule with no errors or crashes.

This behavior is intentional for now, as it keeps the feature simple and non-breaking, while still allowing flexibility in configuration.

---

## Notes

Date matching is intentionally limited to month and day, with no year component. This keeps the feature simple and aligned with recurring broadcast patterns. Doing it this way avoids introducing additional scheduling complexity and does not modify existing scheduling logic beyond adding a higher-priority check. Plus, if you want to change something in a year, just change it in a year.