### PR TITLE
Support date ranges in date_overrides in addition to exact dates.

### DIFF
--- a/fs42/config_processor.py
+++ b/fs42/config_processor.py
@@ -17,15 +17,27 @@ class ConfigProcessor:
         return processed
 
     @staticmethod
-    # validate that this looks like a "Month Day" string (e.g. "December 25")
-    # we use datetime here instead of RangeHint to avoid a circular import
-    # if it's invalid, it just won't ever match and will fall back to weekday scheduling
     def _valid_date_key(date_key):
-        try:
-            datetime.strptime(date_key.strip(), "%B %d")
-            return True
-        except ValueError:
-            return False
+        # validate that this looks like either "Month Day" or "Month Day - Month Day"
+        # raises ConfigurationError with helpful message on failure
+        parts = [part.strip() for part in date_key.split(" - ")]
+
+        if len(parts) not in (1, 2):
+            raise ConfigurationError(
+                f"Invalid date_overrides key '{date_key}'. "
+                "Expected format 'Month Day' or 'Month Day - Month Day'."
+            )
+
+        for part in parts:
+            try:
+                datetime.strptime(part, "%B %d")
+            except ValueError:
+                raise ConfigurationError(
+                    f"Invalid date '{part}' in date_overrides key '{date_key}'. "
+                    "Ensure the day exists for the given month (e.g., April has 30 days)."
+                )
+
+        return True
 
     @staticmethod
     def _process_templates(conf):
@@ -70,10 +82,8 @@ class ConfigProcessor:
         processed_overrides = {}
 
         for date_key, override_value in overrides.items():
-            if not ConfigProcessor._valid_date_key(date_key):
-                raise ConfigurationError(
-                    f"date_overrides entry '{date_key}' for {conf['network_name']} is not a valid month/day like 'December 25'."
-                )
+            # validate date key (will raise ConfigurationError if invalid)
+            ConfigProcessor._valid_date_key(date_key)
 
             if isinstance(override_value, str):
                 template_key = override_value

--- a/fs42/slot_reader.py
+++ b/fs42/slot_reader.py
@@ -56,10 +56,30 @@ class SlotReader:
 
     @staticmethod
     def _date_key_matches(date_key, when: datetime):
-        # match date_overrides keys like "April 23" (case-insensitive)
+        # match date_overrides keys like "April 23" or "December 24 - January 2"
         try:
-            parsed = datetime.strptime(date_key.strip(), "%B %d")
-            return parsed.month == when.month and parsed.day == when.day
+            parts = [part.strip() for part in date_key.split(" - ")]
+
+            if len(parts) == 1:
+                parsed = datetime.strptime(parts[0], "%B %d")
+                return parsed.month == when.month and parsed.day == when.day
+
+            if len(parts) == 2:
+                start = datetime.strptime(parts[0], "%B %d")
+                end = datetime.strptime(parts[1], "%B %d")
+
+                current_md = (when.month, when.day)
+                start_md = (start.month, start.day)
+                end_md = (end.month, end.day)
+
+                # normal same-year range, e.g. "April 23 - April 25"
+                if start_md <= end_md:
+                    return start_md <= current_md <= end_md
+
+                # wraparound range, e.g. "December 24 - January 2"
+                return current_md >= start_md or current_md <= end_md
+
+            return False
         except ValueError:
             return False
 

--- a/fs42/station_config_schema.json
+++ b/fs42/station_config_schema.json
@@ -197,9 +197,9 @@
         },
         "date_overrides": {
           "type": "object",
-          "description": "Optional exact-date schedule overrides keyed by month/day like 'December 25'. These take precedence over weekday schedules for matching dates.",
+          "description": "Optional exact-date schedule overrides keyed by month/day like 'December 25' or a date range. These take precedence over weekday schedules for matching dates.",
           "propertyNames": {
-            "pattern": "^[A-Z][a-z]+ [0-3]?[0-9]$"
+            "pattern": "^[A-Z][a-z]+ [0-3]?[0-9]( - [A-Z][a-z]+ [0-3]?[0-9])?$"
           },
           "additionalProperties": {
             "oneOf": [


### PR DESCRIPTION
I added support for date ranges in addition to exact dates in `date_overrides`

Keys can now be either:

```json
"April 23"
```

or:

```json
"April 23 - April 25"
```

This also supports wraparound ranges like:

```json
"December 24 - January 2"
```

I also tightened validation so invalid dates such as "April 31" fail during config processing with a clear Configuration Error, instead of silently never matching during scheduling.