### PR TITLE
Enhance automatic bumps with video backgrounds and text controls

### DIFF
--- a/fs42/autobump_agent.py
+++ b/fs42/autobump_agent.py
@@ -1,6 +1,7 @@
 import random
 import sys
 import os
+import subprocess
 
 sys.path.append(os.getcwd())
 from fs42.catalog_entry import CatalogEntry
@@ -40,8 +41,19 @@ class AutoBumpAgent:
         ab_config = station_config["autobump"]
 
         # first, check duration:
+        # if the user set a duration, respect that as the bump length
+        # otherwise, video-backed autobumps can use the video length as a default
         if "duration" not in ab_config or not ab_config["duration"]:
-            ab_config["duration"] = 7
+            if "bg_video" in ab_config and ab_config["bg_video"]:
+                video_duration = AutoBumpAgent.get_bg_video_duration(ab_config["bg_video"])
+                loop_count = AutoBumpAgent.get_bg_video_loop_count(ab_config)
+
+                if video_duration:
+                    ab_config["duration"] = video_duration * loop_count
+                else:
+                    ab_config["duration"] = 7
+            else:
+                ab_config["duration"] = 7
 
         msg_bump = AutoBumpAgent.message_bump(ab_config, AutoBumpAgent.base_url)
         next_bump = AutoBumpAgent.next_up_bump(ab_config, AutoBumpAgent.base_url, station_config["network_name"])
@@ -78,6 +90,78 @@ class AutoBumpAgent:
         return block
 
     @staticmethod
+    def get_bg_video_loop_count(config):
+        try:
+            loop_count = int(config.get("bg_video_loop_count", 1))
+            return max(loop_count, 1)
+        except Exception:
+            return 1
+
+    @staticmethod
+    def get_bg_video_duration(bg_video):
+        if str(bg_video).startswith("http"):
+            return None
+
+        video_path = AutoBumpAgent.resolve_bg_video_path(bg_video)
+
+        if not video_path or not os.path.exists(video_path):
+            return None
+
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    video_path
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            if result.returncode != 0:
+                return None
+
+            duration = float(result.stdout.strip())
+            return duration if duration > 0 else None
+        except Exception:
+            return None
+
+    @staticmethod
+    def resolve_bg_video_path(bg_video):
+        # full paths can be probed directly
+        if os.path.isabs(str(bg_video)):
+            return bg_video
+
+        # try the configured value relative to the current working directory
+        if os.path.exists(bg_video):
+            return bg_video
+
+        # bare filenames are served from static/bump/video, similar to bg_music
+        video_path = os.path.join("fs42", "fs42_server", "static", "bump", "video", str(bg_video))
+        if os.path.exists(video_path):
+            return video_path
+
+        return None
+
+    @staticmethod
+    def resolve_bg_video_url(bg_video):
+        if str(bg_video).startswith("http"):
+            return bg_video
+
+        # absolute URLs served from this FS42 instance can pass through
+        if str(bg_video).startswith("/"):
+            return bg_video
+
+        # bare filenames are served from static/bump/video
+        return f"http://127.0.0.1:4242/static/bump/video/{bg_video}"
+
+    @staticmethod
     def generate_bump_query(config: dict) -> str:
         """
         Generate a query string for bump.html with the specified parameters.
@@ -91,6 +175,13 @@ class AutoBumpAgent:
                 - bg_color: Background color (hex format, e.g., '#ff0000')
                 - fg_color: Text color (hex format, e.g., '#ffffff')
                 - bg: Background image URL
+                - bg_video: Background video URL or filename
+                - bg_video_loop_count: Number of times to play the background video if no duration is set
+                - bg_video_audio: Whether to use background video audio when bg_music is not set
+                - text_position: Position of text overlay
+                - text_delay: Delay before text appears, in seconds
+                - text_fade_in: Text fade-in duration, in seconds
+                - text_fade_out: Text fade-out duration, in seconds
                 - css: URL to custom CSS override file
                 - next_network: Network name to fetch next 3 upcoming shows
                 - duration: Auto-hide after specified milliseconds (0 = no auto-hide)
@@ -115,6 +206,13 @@ class AutoBumpAgent:
             "bg_color": "bg_color",
             "fg_color": "fg_color",
             "bg": "bg",
+            "bg_video": "bg_video",
+            "bg_video_loop_count": "bg_video_loop_count",
+            "bg_video_audio": "bg_video_audio",
+            "text_position": "text_position",
+            "text_delay": "text_delay",
+            "text_fade_in": "text_fade_in",
+            "text_fade_out": "text_fade_out",
             "css": "css",
             "next_network": "next_network",
             "duration": "duration",
@@ -133,6 +231,10 @@ class AutoBumpAgent:
                     # Convert filename to full URL if not already a URL
                     if not str(value).startswith("http"):
                         value = f"http://127.0.0.1:4242/static/bump/music/{value}"
+                elif key == "bg_video":
+                    value = AutoBumpAgent.resolve_bg_video_url(value)
+                elif key == "bg_video_audio":
+                    value = str(value).lower()
                 params[url_param] = value
 
         # Generate query string
@@ -158,6 +260,25 @@ def main():
     }
     print("Retro with programming:")
     print(f"Query: {AutoBumpAgent.generate_bump_query(retro_config)}")
+    print()
+
+    # Test video background with explicit duration
+    # this protects users from very long videos creating very long autobumps
+    video_config = {
+        "title": "FSTV",
+        "subtitle": "Field Station Television",
+        "variation": "retro",
+        "bg_video": "example.mp4",
+        "bg_video_loop_count": 2,
+        "bg_video_audio": True,
+        "text_position": "right",
+        "text_delay": 1.5,
+        "text_fade_in": 0.75,
+        "text_fade_out": 0.5,
+        "duration": 12
+    }
+    print("Video background:")
+    print(f"Query: {AutoBumpAgent.generate_bump_query(video_config)}")
     print()
 
     # Test complete configuration

--- a/fs42/fs42_server/static/bump/bump.css
+++ b/fs42/fs42_server/static/bump/bump.css
@@ -47,9 +47,24 @@ body {
     background: linear-gradient(
         45deg,
         rgba(0, 0, 0, 0.3) 0%,
-        rgba(0, 0, 0, 0.1) 50%,
-        rgba(0, 0, 0, 0.3) 100%
+                                rgba(0, 0, 0, 0.1) 50%,
+                                rgba(0, 0, 0, 0.3) 100%
     );
+}
+
+#bgVideoPlayer {
+position: absolute;
+top: 0;
+left: 0;
+width: 100%;
+height: 100%;
+object-fit: cover;
+z-index: 0;
+background: #000000;
+}
+
+.bump-container.video-bg .background-layer {
+    opacity: 0;
 }
 
 .content-area {
@@ -65,6 +80,50 @@ body {
     text-align: center;
 }
 
+.content-area.text-hidden {
+    opacity: 0;
+}
+
+.bump-container.text-position-left .content-area {
+    align-items: flex-start;
+    text-align: left;
+}
+
+.bump-container.text-position-right .content-area {
+    align-items: flex-end;
+    text-align: right;
+}
+
+.bump-container.text-position-center .content-area {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.bump-container.text-position-top-left .content-area {
+    align-items: flex-start;
+    justify-content: flex-start;
+    text-align: left;
+}
+
+.bump-container.text-position-top-right .content-area {
+    align-items: flex-end;
+    justify-content: flex-start;
+    text-align: right;
+}
+
+.bump-container.text-position-bottom-left .content-area {
+    align-items: flex-start;
+    justify-content: flex-end;
+    text-align: left;
+}
+
+.bump-container.text-position-bottom-right .content-area {
+    align-items: flex-end;
+    justify-content: flex-end;
+    text-align: right;
+}
+
 .title-section {
     margin-bottom: 30px;
     animation: fadeInUp 1.5s ease-out;
@@ -77,9 +136,9 @@ body {
     color: #ffffff;
     text-transform: uppercase;
     letter-spacing: 3px;
-    text-shadow: 
-        0 0 10px rgba(255, 255, 255, 0.3),
-        0 2px 4px rgba(0, 0, 0, 0.8);
+    text-shadow:
+    0 0 10px rgba(255, 255, 255, 0.3),
+    0 2px 4px rgba(0, 0, 0, 0.8);
     line-height: 1.1;
     margin: 0;
 }
@@ -157,9 +216,9 @@ body {
 
 .bump-container.dark-theme .main-title {
     color: #ffffff;
-    text-shadow: 
-        0 0 20px rgba(255, 255, 255, 0.5),
-        0 2px 8px rgba(0, 0, 0, 0.9);
+    text-shadow:
+    0 0 20px rgba(255, 255, 255, 0.5),
+    0 2px 8px rgba(0, 0, 0, 0.9);
 }
 
 .bump-container.light-theme {
@@ -168,9 +227,9 @@ body {
 
 .bump-container.light-theme .main-title {
     color: #333333;
-    text-shadow: 
-        0 0 10px rgba(255, 255, 255, 0.8),
-        0 2px 4px rgba(0, 0, 0, 0.3);
+    text-shadow:
+    0 0 10px rgba(255, 255, 255, 0.8),
+    0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
 .bump-container.light-theme .subtitle {
@@ -183,53 +242,53 @@ body {
 
 .bump-container.accent-blue .main-title {
     color: #00d4ff;
-    text-shadow: 
-        0 0 20px rgba(0, 212, 255, 0.6),
-        0 2px 8px rgba(0, 0, 0, 0.8);
+    text-shadow:
+    0 0 20px rgba(0, 212, 255, 0.6),
+    0 2px 8px rgba(0, 0, 0, 0.8);
 }
 
 .bump-container.accent-red .main-title {
     color: #ff4757;
-    text-shadow: 
-        0 0 20px rgba(255, 71, 87, 0.6),
-        0 2px 8px rgba(0, 0, 0, 0.8);
+    text-shadow:
+    0 0 20px rgba(255, 71, 87, 0.6),
+    0 2px 8px rgba(0, 0, 0, 0.8);
 }
 
 .bump-container.accent-green .main-title {
     color: #2ed573;
-    text-shadow: 
-        0 0 20px rgba(46, 213, 115, 0.6),
-        0 2px 8px rgba(0, 0, 0, 0.8);
+    text-shadow:
+    0 0 20px rgba(46, 213, 115, 0.6),
+    0 2px 8px rgba(0, 0, 0, 0.8);
 }
 
 .bump-container.accent-purple .main-title {
     color: #a55eea;
-    text-shadow: 
-        0 0 20px rgba(165, 94, 234, 0.6),
-        0 2px 8px rgba(0, 0, 0, 0.8);
+    text-shadow:
+    0 0 20px rgba(165, 94, 234, 0.6),
+    0 2px 8px rgba(0, 0, 0, 0.8);
 }
 
 @media (max-width: 768px) {
     .content-area {
         padding: 20px;
     }
-    
+
     .main-title {
         letter-spacing: 2px;
     }
-    
+
     .subtitle {
         letter-spacing: 0.5px;
     }
-    
+
     .detail-line {
         margin-bottom: 6px;
     }
 }
 
 /* ========================================
-   VARIATION STYLES
-   ======================================== */
+ *  VARIATION STYLES
+ *  ======================================== */
 
 /* VARIATION 1: Modern (default) */
 .bump-container.variation-modern {
@@ -239,9 +298,9 @@ body {
 .bump-container.variation-modern .main-title {
     font-family: 'Orbitron', monospace;
     color: #00d4ff;
-    text-shadow: 
-        0 0 20px rgba(0, 212, 255, 0.6),
-        0 2px 8px rgba(0, 0, 0, 0.8);
+    text-shadow:
+    0 0 20px rgba(0, 212, 255, 0.6),
+    0 2px 8px rgba(0, 0, 0, 0.8);
 }
 
 .bump-container.variation-modern .subtitle {
@@ -270,7 +329,7 @@ body {
         transparent,
         transparent 3px,
         rgba(255, 20, 147, 0.03) 3px,
-        rgba(255, 20, 147, 0.03) 6px
+                                          rgba(255, 20, 147, 0.03) 6px
     );
     pointer-events: none;
     z-index: 5;
@@ -279,11 +338,11 @@ body {
 .bump-container.variation-retro .main-title {
     font-family: 'Bebas Neue', cursive;
     color: #ff1493;
-    text-shadow: 
-        0 0 30px rgba(255, 20, 147, 0.8),
-        0 0 60px rgba(255, 20, 147, 0.4),
-        2px 2px 0px #00ffff,
-        4px 4px 0px rgba(0, 255, 255, 0.5);
+    text-shadow:
+    0 0 30px rgba(255, 20, 147, 0.8),
+    0 0 60px rgba(255, 20, 147, 0.4),
+    2px 2px 0px #00ffff,
+    4px 4px 0px rgba(0, 255, 255, 0.5);
     letter-spacing: 8px;
     transform: perspective(500px) rotateX(15deg);
 }
@@ -320,34 +379,34 @@ body {
 .bump-container.variation-corporate .main-title {
     font-family: 'Bebas Neue', cursive;
     color: #ffffff;
-    text-shadow: 
-        3px 3px 0px #003d7a,
-        6px 6px 0px #002952,
-        0 0 30px rgba(255, 255, 255, 0.6);
+    text-shadow:
+    3px 3px 0px #003d7a,
+    6px 6px 0px #002952,
+    0 0 30px rgba(255, 255, 255, 0.6);
     font-weight: 900;
     letter-spacing: 6px;
     animation: corporate90sGlow 2s ease-in-out infinite alternate;
 }
 
 @keyframes corporate90sGlow {
-    0% { text-shadow: 
+    0% { text-shadow:
         3px 3px 0px #003d7a,
         6px 6px 0px #002952,
         0 0 30px rgba(255, 255, 255, 0.6); }
-    100% { text-shadow: 
-        3px 3px 0px #003d7a,
-        6px 6px 0px #002952,
-        0 0 50px rgba(255, 255, 255, 0.9),
-        0 0 70px rgba(0, 204, 255, 0.4); }
+        100% { text-shadow:
+            3px 3px 0px #003d7a,
+            6px 6px 0px #002952,
+            0 0 50px rgba(255, 255, 255, 0.9),
+            0 0 70px rgba(0, 204, 255, 0.4); }
 }
 
 .bump-container.variation-corporate .subtitle {
     color: #ffff00;
     font-weight: 700;
     font-style: normal;
-    text-shadow: 
-        2px 2px 0px #cc9900,
-        0 0 15px rgba(255, 255, 0, 0.8);
+    text-shadow:
+    2px 2px 0px #cc9900,
+    0 0 15px rgba(255, 255, 0, 0.8);
     text-transform: uppercase;
     letter-spacing: 3px;
 }
@@ -355,28 +414,28 @@ body {
 .bump-container.variation-corporate .detail-line {
     color: #ffffff;
     font-weight: 600;
-    text-shadow: 
-        2px 2px 0px #0066cc,
-        0 0 10px rgba(255, 255, 255, 0.5);
+    text-shadow:
+    2px 2px 0px #0066cc,
+    0 0 10px rgba(255, 255, 255, 0.5);
     text-transform: uppercase;
     letter-spacing: 2px;
 }
 
 .bump-container.variation-corporate .content-area {
-    background: linear-gradient(135deg, 
-        rgba(255, 255, 255, 0.15) 0%, 
-        rgba(255, 255, 255, 0.05) 50%, 
-        rgba(0, 102, 204, 0.1) 100%);
+    background: linear-gradient(135deg,
+                                rgba(255, 255, 255, 0.15) 0%,
+                                rgba(255, 255, 255, 0.05) 50%,
+                                rgba(0, 102, 204, 0.1) 100%);
     border: 2px solid rgba(255, 255, 255, 0.3);
     border-radius: 12px;
     padding: 30px;
     margin: auto;
     max-width: 80%;
     max-height: 70%;
-    box-shadow: 
-        inset 1px 1px 3px rgba(255, 255, 255, 0.3),
-        inset -1px -1px 3px rgba(0, 0, 0, 0.2),
-        0 8px 25px rgba(0, 0, 0, 0.3);
+    box-shadow:
+    inset 1px 1px 3px rgba(255, 255, 255, 0.3),
+    inset -1px -1px 3px rgba(0, 0, 0, 0.2),
+    0 8px 25px rgba(0, 0, 0, 0.3);
     backdrop-filter: blur(5px);
 }
 
@@ -398,7 +457,7 @@ body {
         transparent,
         transparent 2px,
         rgba(0, 255, 0, 0.02) 2px,
-        rgba(0, 255, 0, 0.02) 4px
+                                          rgba(0, 255, 0, 0.02) 4px
     );
     pointer-events: none;
     z-index: 5;
@@ -413,9 +472,9 @@ body {
 .bump-container.variation-terminal .main-title {
     font-family: 'JetBrains Mono', monospace;
     color: #00ff00;
-    text-shadow: 
-        0 0 10px rgba(0, 255, 0, 0.8),
-        0 0 20px rgba(0, 255, 0, 0.4);
+    text-shadow:
+    0 0 10px rgba(0, 255, 0, 0.8),
+    0 0 20px rgba(0, 255, 0, 0.4);
     font-weight: 700;
     letter-spacing: 4px;
     animation: terminalFlicker 3s ease-in-out infinite;

--- a/fs42/fs42_server/static/bump/bump.html
+++ b/fs42/fs42_server/static/bump/bump.html
@@ -10,11 +10,16 @@
     <div class="bump-container" id="bumpContainer">
         <div class="background-layer" id="backgroundLayer"></div>
 
+        <!-- Optional background video element -->
+        <video id="bgVideoPlayer" preload="auto" playsinline style="display: none;">
+            Your browser does not support the video element.
+        </video>
+
         <div class="countdown-timer" id="countdownTimer" style="display: none;">
             <span id="countdownDisplay">0:00</span>
         </div>
 
-        <div class="content-area">
+        <div class="content-area" id="contentArea" style="opacity: 0;">
             <div class="title-section">
                 <h1 class="main-title" id="mainTitle">FIELDSTATION42</h1>
             </div>
@@ -35,7 +40,7 @@
             Your browser does not support the audio element.
         </audio>
     </div>
-    
+
     <script src="../fs42_client.js"></script>
     <script src="../common.js"></script>
     <script src="bump.js"></script>

--- a/fs42/fs42_server/static/bump/bump.js
+++ b/fs42/fs42_server/static/bump/bump.js
@@ -2,6 +2,13 @@ class StationBump {
     constructor(config = {}) {
         this.container = document.getElementById('bumpContainer');
         this.backgroundLayer = document.getElementById('backgroundLayer');
+        this.bgVideoPlayer = document.getElementById('bgVideoPlayer');
+        this.contentArea = document.getElementById('contentArea');
+
+        if (this.contentArea) {
+            this.contentArea.classList.add('text-hidden');
+        }
+
         this.mainTitle = document.getElementById('mainTitle');
         this.subtitle = document.getElementById('subtitle');
         this.detailLine1 = document.getElementById('detailLine1');
@@ -11,11 +18,16 @@ class StationBump {
         this.countdownTimer = document.getElementById('countdownTimer');
         this.countdownDisplay = document.getElementById('countdownDisplay');
 
+        this.videoLoopsRemaining = 1;
+
         this.config = {
             title: 'FieldStation42',
             subtitle: 'Big Time Watching Is Here!',
             details: ['Transmitting 24/7', 'On FieldStation42', 'It\'s up to you!'],
             backgroundImage: null,
+            backgroundVideo: null,
+            backgroundVideoLoopCount: 1,
+            backgroundVideoAudio: true,
             backgroundColor: '#000000',
             bgColor: null,
             fgColor: null,
@@ -28,23 +40,29 @@ class StationBump {
             bgMusic: null,
             loopMusic: true,
             countdown: false,
+            textPosition: null,
+            textDelay: 0,
+            textFadeIn: 0,
+            textFadeOut: 0,
+            textHideBeforeEnd: 0,
             ...config
         };
-        
+
         this.init();
     }
-    
+
     async init() {
         await this.applyConfiguration();
+        this.setupTextPresentation();
         this.setupAutoHide();
         this.setupCountdown();
     }
-    
+
     async applyConfiguration() {
         // Set content
         this.mainTitle.textContent = this.config.title;
         this.subtitle.textContent = this.config.subtitle;
-        
+
         // Handle nextUp shows or regular details
         if (this.config.nextUp) {
             await this.loadNextUpShows();
@@ -58,9 +76,11 @@ class StationBump {
                 }
             });
         }
-        
+
         // Set background
-        if (this.config.backgroundImage) {
+        if (this.config.backgroundVideo) {
+            this.setupBackgroundVideo();
+        } else if (this.config.backgroundImage) {
             this.backgroundLayer.style.backgroundImage = `url(${this.config.backgroundImage})`;
             this.container.classList.add('custom-bg');
         } else if (this.config.bgColor) {
@@ -68,15 +88,15 @@ class StationBump {
         } else {
             this.container.style.background = this.config.backgroundColor;
         }
-        
+
         // Apply variation styling
         this.applyVariation();
-        
+
         // Load custom CSS override if provided
         if (this.config.cssOverride) {
             this.loadCSSOverride();
         }
-        
+
         // Set custom text colors (overrides variation defaults if provided)
         if (this.config.fgColor) {
             this.mainTitle.style.color = this.config.fgColor;
@@ -89,23 +109,23 @@ class StationBump {
         // Handle background music
         this.setupBackgroundMusic();
     }
-    
+
     applyVariation() {
         // Remove any existing variation classes
         this.container.classList.remove('variation-modern', 'variation-retro', 'variation-corporate', 'variation-terminal');
-        
+
         // Add the selected variation class
         this.container.classList.add(`variation-${this.config.variation}`);
-        
+
         // Set default colors based on variation (only if custom colors not provided)
-        if (!this.config.bgColor && !this.config.backgroundImage) {
+        if (!this.config.bgColor && !this.config.backgroundImage && !this.config.backgroundVideo) {
             const variationDefaults = this.getVariationDefaults();
             if (variationDefaults.bgColor) {
                 this.container.style.background = variationDefaults.bgColor;
             }
         }
     }
-    
+
     getVariationDefaults() {
         const defaults = {
             modern: {
@@ -125,37 +145,37 @@ class StationBump {
                 fgColor: null
             }
         };
-        
+
         return defaults[this.config.variation] || defaults.modern;
     }
-    
+
     loadCSSOverride() {
         // Remove any existing override CSS
         const existingOverride = document.getElementById('css-override');
         if (existingOverride) {
             existingOverride.remove();
         }
-        
+
         // Create and load new override CSS
         const link = document.createElement('link');
         link.id = 'css-override';
         link.rel = 'stylesheet';
         link.type = 'text/css';
         link.href = this.config.cssOverride;
-        
+
         // Add error handling
         link.onerror = () => {
             console.warn('Failed to load CSS override:', this.config.cssOverride);
         };
-        
+
         link.onload = () => {
             console.log('CSS override loaded successfully:', this.config.cssOverride);
         };
-        
+
         // Append to head to ensure it loads after base styles
         document.head.appendChild(link);
     }
-    
+
     async loadNextUpShows() {
         try {
             const now = new Date();
@@ -176,7 +196,7 @@ class StationBump {
             const scheduleBlocks = await window.fs42Common.fetchSchedule(
                 this.config.nextUp,
                 formatDateForAPI(now),
-                formatDateForAPI(endTime)
+                    formatDateForAPI(endTime)
             );
 
             if (scheduleBlocks && scheduleBlocks.length > 0) {
@@ -187,8 +207,8 @@ class StationBump {
                 let nearEnd = false;
                 if (currentShow) {
                     const currentEnd = currentShow.end_time
-                        ? new Date(currentShow.end_time)
-                        : (upcomingShows.length > 0 ? new Date(upcomingShows[0].start_time) : null);
+                    ? new Date(currentShow.end_time)
+                    : (upcomingShows.length > 0 ? new Date(upcomingShows[0].start_time) : null);
                     if (currentEnd) {
                         nearEnd = (currentEnd - now) <= (5 * 60 * 1000);
                     }
@@ -242,7 +262,26 @@ class StationBump {
             this.detailLine3.style.display = 'none';
         }
     }
-    
+
+    setupTextPresentation() {
+        if (!this.contentArea) return;
+
+        if (this.config.textPosition) {
+            this.container.classList.add(`text-position-${this.config.textPosition}`);
+        }
+
+        const delayMs = Math.max(parseFloat(this.config.textDelay) || 0, 0) * 1000;
+        const fadeInSec = Math.max(parseFloat(this.config.textFadeIn) || 0, 0);
+
+        this.contentArea.style.opacity = '0';
+        this.contentArea.style.transition = fadeInSec > 0 ? `opacity ${fadeInSec}s ease-in` : 'none';
+
+        setTimeout(() => {
+            this.contentArea.classList.remove('text-hidden');
+            this.contentArea.style.opacity = '1';
+        }, delayMs);
+    }
+
     setupCountdown() {
         if (!this.config.countdown || this.config.duration <= 0) return;
 
@@ -271,23 +310,79 @@ class StationBump {
         if (this.config.duration > 0) {
             // Enforce minimum duration of 2 seconds (2000ms)
             const adjustedDuration = Math.max(this.config.duration, 2000);
-            
+
             // Start fade animation 1 second early so total duration matches exactly
             const fadeStartTime = Math.max(adjustedDuration - 1000, 0);
-            
+
+            // Optionally hide the text before the bump itself ends
+            if (this.contentArea && this.config.textHideBeforeEnd > 0) {
+                const fadeOutSec = Math.max(parseFloat(this.config.textFadeOut) || 0, 0);
+                const hideBeforeEndMs = this.config.textHideBeforeEnd * 1000;
+                const fadeOutMs = fadeOutSec * 1000;
+
+                const textFadeStartTime = Math.max(
+                    adjustedDuration - hideBeforeEndMs - fadeOutMs,
+                    0
+                );
+
+                setTimeout(() => {
+                    this.contentArea.style.transition = fadeOutSec > 0 ? `opacity ${fadeOutSec}s ease-out` : 'none';
+                    this.contentArea.style.opacity = '0';
+                }, textFadeStartTime);
+            }
+
             setTimeout(() => {
                 this.fadeOut();
             }, fadeStartTime);
         }
     }
-    
+
     fadeOut() {
+        if (this.contentArea && this.config.textFadeOut > 0) {
+            this.contentArea.style.transition = `opacity ${this.config.textFadeOut}s ease-out`;
+            this.contentArea.style.opacity = '0';
+        }
+
         this.container.style.transition = 'opacity 1s ease-out';
         this.container.style.opacity = '0';
-        
+
         setTimeout(() => {
             this.container.style.display = 'none';
         }, 1000);
+    }
+
+    setupBackgroundVideo() {
+        if (!this.config.backgroundVideo || !this.bgVideoPlayer) return;
+
+        this.videoLoopsRemaining = Math.max(parseInt(this.config.backgroundVideoLoopCount) || 1, 1);
+
+        this.bgVideoPlayer.src = this.config.backgroundVideo;
+        this.bgVideoPlayer.style.display = 'block';
+        this.bgVideoPlayer.playsInline = true;
+        this.bgVideoPlayer.loop = false;
+
+        // If bg_music is set, keep video audio muted so audio behavior remains predictable.
+        // Otherwise, use video audio unless bg_video_audio=false.
+        this.bgVideoPlayer.muted = !!this.config.bgMusic || !this.config.backgroundVideoAudio;
+
+        this.container.classList.add('video-bg');
+
+        this.bgVideoPlayer.addEventListener('ended', () => {
+            this.videoLoopsRemaining--;
+
+            if (this.videoLoopsRemaining > 0) {
+                this.bgVideoPlayer.currentTime = 0;
+                this.bgVideoPlayer.play().catch(error => {
+                    console.warn('Background video replay failed:', error);
+                });
+            }
+        });
+
+        this.bgVideoPlayer.play().then(() => {
+            console.log('Background video started successfully');
+        }).catch(error => {
+            console.warn('Background video autoplay failed:', error);
+        });
     }
 
     setupBackgroundMusic() {
@@ -326,11 +421,11 @@ class StationBump {
             }, 50); // Fade over ~1 second
         }
     }
-    
+
     // Static method to create bump with URL parameters
     static fromURLParams() {
         const params = new URLSearchParams(window.location.search);
-        
+
         const config = {
             title: params.get('title') || 'FieldStation42',
             subtitle: params.get('subtitle') || 'Its Up to you!',
@@ -340,6 +435,9 @@ class StationBump {
                 params.get('detail3') || 'Sweet.'
             ].filter(Boolean),
             backgroundImage: params.get('bg') || null,
+            backgroundVideo: params.get('bg_video') || null,
+            backgroundVideoLoopCount: parseInt(params.get('bg_video_loop_count')) || 1,
+            backgroundVideoAudio: params.get('bg_video_audio') !== 'false',
             backgroundColor: params.get('bgcolor') || '#000000',
             bgColor: params.get('bg_color') || null,
             fgColor: params.get('fg_color') || null,
@@ -351,16 +449,22 @@ class StationBump {
             cssOverride: params.get('css') || null,
             bgMusic: params.get('bg_music') || null,
             loopMusic: params.get('loopmusic') !== 'false',
-            countdown: params.get('countdown') === 'true'
+            countdown: params.get('countdown') === 'true',
+            textPosition: params.get('text_position') || null,
+            textDelay: parseFloat(params.get('text_delay')) || 0,
+            textFadeIn: parseFloat(params.get('text_fade_in')) || 0,
+            textFadeOut: parseFloat(params.get('text_fade_out')) || 0,
+            textHideBeforeEnd: parseFloat(params.get('text_hide_before_end')) || 0
         };
-        
+
         return new StationBump(config);
     }
-    
+
     // Method to update content dynamically
     async updateContent(newConfig) {
         Object.assign(this.config, newConfig);
         await this.applyConfiguration();
+        this.setupTextPresentation();
     }
 }
 
@@ -380,7 +484,7 @@ window.configureBump = async function(config) {
 document.addEventListener('DOMContentLoaded', () => {
     // Check if URL parameters are provided
     const hasParams = window.location.search.length > 0;
-    
+
     if (hasParams) {
         window.currentBump = StationBump.fromURLParams();
     } else {

--- a/fs42/station_config_schema.json
+++ b/fs42/station_config_schema.json
@@ -4,11 +4,16 @@
   "title": "FieldStation42 Station Configuration",
   "description": "Schema for FieldStation42 station configuration files",
   "type": "object",
-  "required": ["station_conf"],
+  "required": [
+    "station_conf"
+  ],
   "properties": {
     "station_conf": {
       "type": "object",
-      "required": ["network_name", "channel_number"],
+      "required": [
+        "network_name",
+        "channel_number"
+      ],
       "properties": {
         "network_name": {
           "type": "string",
@@ -24,7 +29,13 @@
         },
         "network_type": {
           "type": "string",
-          "enum": ["standard", "web", "guide", "loop", "streaming"],
+          "enum": [
+            "standard",
+            "web",
+            "guide",
+            "loop",
+            "streaming"
+          ],
           "description": "Type of network station"
         },
         "schedule_increment": {
@@ -37,7 +48,11 @@
         },
         "break_strategy": {
           "type": "string",
-          "enum": ["standard", "end", "center"],
+          "enum": [
+            "standard",
+            "end",
+            "center"
+          ],
           "description": "Strategy for commercial breaks"
         },
         "commercial_free": {
@@ -106,12 +121,27 @@
         },
         "media_filter": {
           "type": "string",
-          "enum": ["video", "audio", "mixed"],
+          "enum": [
+            "video",
+            "audio",
+            "mixed"
+          ],
           "description": "Filter media by type: video only, audio only, or mixed (default: video)"
         },
         "video_scramble_fx": {
           "type": "string",
-          "enum": ["horizontal_line", "diagonal_lines", "static_overlay", "pixel_block", "color_inversion", "severe_noise", "wavy", "random_block", "chunky_scramble", "spicy"],
+          "enum": [
+            "horizontal_line",
+            "diagonal_lines",
+            "static_overlay",
+            "pixel_block",
+            "color_inversion",
+            "severe_noise",
+            "wavy",
+            "random_block",
+            "chunky_scramble",
+            "spicy"
+          ],
           "description": "Preset video scrambling effect"
         },
         "station_fx": {
@@ -179,9 +209,54 @@
             "bg_music": {
               "type": "string"
             },
+            "bg_video": {
+              "type": "string",
+              "description": "Path or URL to a background video for the autobump. Bare filenames are served from static/bump/video."
+            },
+            "bg_video_loop_count": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of times to play the background video when autobump duration is inferred from the video length. Defaults to 1."
+            },
+            "bg_video_audio": {
+              "type": "boolean",
+              "description": "Whether to use the background video's audio when bg_music is not set. Defaults to true."
+            },
+            "text_position": {
+              "type": "string",
+              "enum": [
+                "left",
+                "right",
+                "center",
+                "top-left",
+                "top-right",
+                "bottom-left",
+                "bottom-right"
+              ],
+              "description": "Position of the autobump text overlay."
+            },
+            "text_delay": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Delay in seconds before the autobump text appears."
+            },
+            "text_fade_in": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Fade-in duration in seconds for the autobump text."
+            },
+            "text_fade_out": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Fade-out duration in seconds for the autobump text."
+            },
             "strategy": {
               "type": "string",
-              "enum": ["both", "end", "start"]
+              "enum": [
+                "both",
+                "end",
+                "start"
+              ]
             }
           }
         },
@@ -424,7 +499,11 @@
           "description": "Stream configurations for streaming networks",
           "items": {
             "type": "object",
-            "required": ["url", "duration", "title"],
+            "required": [
+              "url",
+              "duration",
+              "title"
+            ],
             "properties": {
               "url": {
                 "type": "string",
@@ -464,7 +543,9 @@
         },
         "event": {
           "type": "string",
-          "enum": ["signoff"],
+          "enum": [
+            "signoff"
+          ],
           "description": "Special event for this time slot"
         },
         "overrides": {
@@ -489,7 +570,11 @@
         },
         "break_strategy": {
           "type": "string",
-          "enum": ["standard", "end", "center"],
+          "enum": [
+            "standard",
+            "end",
+            "center"
+          ],
           "description": "Commercial break strategy"
         },
         "schedule_increment": {
@@ -532,18 +617,34 @@
               "description": "Number of episodes in marathon"
             }
           },
-          "required": ["chance", "count"]
+          "required": [
+            "chance",
+            "count"
+          ]
         },
         "video_scramble_fx": {
           "oneOf": [
             {
               "type": "string",
-              "enum": ["horizontal_line", "diagonal_lines", "static_overlay", "pixel_block", "color_inversion", "severe_noise", "wavy", "random_block", "chunky_scramble", "spicy"],
+              "enum": [
+                "horizontal_line",
+                "diagonal_lines",
+                "static_overlay",
+                "pixel_block",
+                "color_inversion",
+                "severe_noise",
+                "wavy",
+                "random_block",
+                "chunky_scramble",
+                "spicy"
+              ],
               "description": "Video scrambling effect"
             },
             {
               "type": "boolean",
-              "enum": [false],
+              "enum": [
+                false
+              ],
               "description": "Disable video scrambling (false)"
             }
           ]


### PR DESCRIPTION
## Overview

This PR adds two related improvements to AutoBumps:

1. Video-backed AutoBumps.
2. New text layout and timing controls that work for both regular AutoBumps and video-backed AutoBumps.

AutoBumps already support generated text, background colors/images, styling variations, schedule-aware “coming up next” details, and optional background music. This change expands that system so users can build more polished station bumpers without replacing the existing AutoBump workflow.

The text controls are intentionally available to all AutoBumps, not only video AutoBumps. Users can use them with static background colors, background images, background music, or video backgrounds.

Existing AutoBump configurations continue to work without changes.

## New text layout and timing controls

This PR adds several optional controls for how AutoBump text appears, where it appears, and when it disappears.

These options are useful for video templates, but they are not video-only. They can also be used with existing background image/color AutoBumps.

| Option | Default | Meaning |
|---|---:|---|
| `text_position` | unset | Use the existing centered AutoBump layout. |
| `text_delay` | `0` | Text appears immediately. |
| `text_fade_in` | `0` | No custom fade-in duration. |
| `text_fade_out` | `0` | No custom text fade-out duration. |
| `text_hide_before_end` | `0` | Text does not hide early. |

### `text_position`

```json
"text_position": "bottom-right"
```

Controls where the AutoBump text block is placed.

Supported values:

```text
left
right
center
top-left
top-right
top-center
bottom-left
bottom-right
bottom-center
```

For normal AutoBumps, text is positioned relative to the full AutoBump viewport.

For video-backed AutoBumps, text is positioned relative to the rendered video frame. This is especially useful when the video does not fill the entire viewport, such as with `object-fit: contain`, because the text stays aligned to the actual video template instead of drifting into the letterbox or pillarbox area.

### `text_delay`

```json
"text_delay": 4.25
```

Delays the text appearance by the specified number of seconds.

For non-video AutoBumps, this delay is relative to the beginning of the AutoBump.

For video-backed AutoBumps, this delay is relative to the beginning of each video loop. This allows looping video templates to keep the text synchronized each time the video repeats.

### `text_fade_in`

```json
"text_fade_in": 0.75
```

Controls how long the text fade-in takes, in seconds.

### `text_fade_out`

```json
"text_fade_out": 0.75
```

Controls how long the text fade-out takes, in seconds.

### `text_hide_before_end`

```json
"text_hide_before_end": 3.25
```

Controls when the text should disappear.

For non-video AutoBumps, this is relative to the end of the AutoBump.

For video-backed AutoBumps, this is relative to the end of each video loop. This allows the text to disappear at the right moment in a looping video template instead of only disappearing once at the end of the full AutoBump duration.

## Example: regular AutoBump with text timing controls

This example does not use a video background. It uses the new text controls with a normal generated AutoBump.

```json
"autobump": {
  "title": "CINEMAX",
  "subtitle": "Coming Up Next",
  "next_network": "CINE",
  "variation": "modern",
  "strategy": "both",
  "duration": 12,
  "text_position": "top-center",
  "text_delay": 2,
  "text_fade_in": 0.75,
  "text_fade_out": 0.75,
  "text_hide_before_end": 2
}
```

In this example, the AutoBump lasts 12 seconds. The text appears after 2 seconds, fades in over 0.75 seconds, and fades out so that it is hidden 2 seconds before the AutoBump ends.

## New video background controls

| Option | Default | Meaning |
|---|---:|---|
| `bg_video` | unset | No background video is used. |
| `bg_video_audio` | `true` | Use the video’s audio unless `bg_music` is set. |
| `bg_video_loop_count` | `1` | Number of video loops to use when no explicit `duration` is set. |

### `bg_video`

```json
"bg_video": "next_up.webm"
```

Specifies a WebM video file to use as the AutoBump background.

AutoBump background videos should be WebM files. Place background video files in:

```text
fs42/fs42_server/static/bump/video/
```

For example, if you place this file:

```text
fs42/fs42_server/static/bump/video/nickelodeon.webm
```

you can reference it in the station configuration with:

```json
"bg_video": "nickelodeon.webm"
```

Full URLs are also supported, but they should still point to WebM video content.

### `bg_video_audio`

```json
"bg_video_audio": true
```

Controls whether the background video’s own audio should be used.

Defaults to `true`.

Behavior:

```text
bg_music is not set & bg_video_audio is true
= video attempts to play with its own audio

bg_music is not set & bg_video_audio is false
= video plays muted

bg_music is set
= video is muted and bg_music is used as the audio source
```

If a browser or webview blocks unmuted autoplay, the video retries muted so the visual AutoBump can still play.

### `bg_video_loop_count`

```json
"bg_video_loop_count": 3
```

Controls how many times a background video should be looped. AutoBump duration can be inferred automatically from this.

The duration hierarchy is:

```text
explicit duration
= respected as-is

no explicit duration & detectable bg_video duration
= use video duration × bg_video_loop_count (default 1)

no explicit duration & no detectable bg_video duration
= fall back to 7 seconds
```

When FS42 provides a longer duration, such as during a fill-break AutoBump, the video loops visually for the full AutoBump duration.

## Example: video AutoBump with text controls

```json
"autobump": {
  "title": "APOLLO 13",
  "subtitle": "Starring:",
  "detail1": "Tom Hanks",
  "detail2": "Gary Sinise",
  "detail3": "Kevin Bacon",
  "variation": "modern",
  "strategy": "both",
  "bg_video": "cinemax.webm",
  "bg_video_audio": true,
  "duration": 19,
  "text_position": "right",
  "text_delay": 4.25,
  "text_fade_in": 0.75,
  "text_fade_out": 0.75,
  "text_hide_before_end": 3.25
}
```

This allows a user to design a video template where text appears and disappears at specific moments in the video.

## Example: video background with separate background music

```json
"autobump": {
  "title": "Nickelodeon",
  "subtitle": "Coming Up Next",
  "next_network": "NICK",
  "variation": "retro",
  "strategy": "both",
  "bg_video": "nickelodeon.webm",
  "bg_music": "nicktune.mp3",
  "duration": 15
}
```

When `bg_music` is set, the background video is muted and the existing `bg_music` behavior is used.

Audio files continue to resolve from:

```text
fs42/fs42_server/static/bump/music/
```

## Example: inferred duration from video loop count

```json
"autobump": {
  "title": "You're Watching",
  "subtitle": "FieldStation42",
  "variation": "corporate",
  "strategy": "both",
  "bg_video": "short_loop.webm",
  "bg_video_loop_count": 4
}
```

If no explicit `duration` is set, FS42 attempts to detect the video duration with `ffprobe` and uses:

```text
video duration × bg_video_loop_count
```

If the duration cannot be detected, it falls back to the existing 7 second default.

## Fill-break behavior

This PR also supports video backgrounds during fill-break AutoBumps.

For example:

```json
"autobump": {
  "title": "This bump repeats",
  "subtitle": "Your content doesn't. FieldStation42.",
  "variation": "modern",
  "strategy": "both",
  "fill_break": 1.0,
  "bg_video": "video.webm",
  "bg_video_audio": true,
  "text_position": "right",
  "text_delay": 4.25,
  "text_fade_in": 0.75,
  "text_fade_out": 0.75,
  "text_hide_before_end": 3.25
}
```

If the break duration is longer than the video, the video loops for the full AutoBump duration. The text timing is applied per video loop, so the text appears and disappears in sync with the video template each time it repeats.

## Files changed

### `fs42/autobump_agent.py`

Adds backend support for passing new AutoBump options into the generated AutoBump URL.

Also adds video duration detection via `ffprobe` when `bg_video` is configured and no explicit `duration` is set.

### `fs42/fs42_server/static/bump/bump.html`

Adds an optional background video element:

```html
<video id="bgVideoPlayer" preload="auto" playsinline style="display: none;">
```

The content area now starts hidden to prevent text flashing briefly before JavaScript applies `text_delay`.

### `fs42/fs42_server/static/bump/bump.js`

Adds frontend support for background video playback, video audio behavior, video looping, text positioning, text animation. 

For video-backed AutoBumps, text timing is tied to each video loop.

For non-video AutoBumps, text timing remains tied to the AutoBump duration.

This preserves the existing behavior for users who are using regular AutoBumps, background images, background colors, or `bg_music`.

### `fs42/fs42_server/static/bump/bump.css`

Adds styling for text, fullscreen background video, video-backed background layering. The background video uses `object-fit: contain` so the entire video template is visible instead of being cropped.

### `fs42/station_config_schema.json`

Adds schema entries for the new AutoBump fields.

## Backwards compatibility

This change is backwards compatible.

Existing AutoBump configs that do not use `bg_video` continue to work as before.

Existing `bg_music` behavior is preserved. If `bg_music` is set alongside `bg_video`, the video is muted and `bg_music` is used as the audio source.

The new text controls are also backwards compatible. They are optional, and they work with both existing non-video AutoBumps and new video-backed AutoBumps.

## Future work intentionally left out

This PR intentionally does not add:

```text
multiple named AutoBump templates per station
external metadata API integration (ie TMDB/top-billed actor lookups)
tag/daypart-specific AutoBump template selection
```

Those may be useful later, but this PR keeps the initial feature focused on video background support and the text/layout controls necessary to make AutoBump templates usable.