### PR TITLE
Add runtime mpv audio and subtitle commands

### DIFF
--- a/field_player.py
+++ b/field_player.py
@@ -74,6 +74,9 @@ def input_check():
                 case "web_key":
                     key = q_message.get("key", "")
                     return PlayerOutcome(PlayerState.SUCCESS, f"web_key:{key}")
+                case "mpv_command":
+                    action = q_message.get("action", "")
+                    return PlayerOutcome(PlayerState.SUCCESS, f"mpv_command:{action}")
 
 
     channel_socket = StationManager().server_conf["channel_socket"]

--- a/fs42/fs42_server/api/player.py
+++ b/fs42/fs42_server/api/player.py
@@ -225,6 +225,37 @@ async def player_stop(request: Request):
     command_queue.put({"command": "exit"})
     return {"status": "stopped"}
 
+
+async def _queue_mpv_command(request: Request, action: str):
+    command_queue = request.app.state.player_command_queue
+    if not command_queue:
+        raise HTTPException(status_code=503, detail="Player command queue is not connected.")
+
+    command_queue.put({"command": "mpv_command", "action": action})
+    return {"status": "ok", "command": "mpv_command", "action": action}
+
+
+@router.get("/mpv/toggle-subtitles")
+@router.post("/mpv/toggle-subtitles")
+async def mpv_toggle_subtitles(request: Request):
+    """Toggle subtitle visibility for the active mpv player."""
+    return await _queue_mpv_command(request, "toggle_subtitles")
+
+
+@router.get("/mpv/cycle-subtitles")
+@router.post("/mpv/cycle-subtitles")
+async def mpv_cycle_subtitles(request: Request):
+    """Cycle through available subtitle tracks for the active mpv player."""
+    return await _queue_mpv_command(request, "cycle_subtitles")
+
+
+@router.get("/mpv/cycle-audio")
+@router.post("/mpv/cycle-audio")
+async def mpv_cycle_audio(request: Request):
+    """Cycle through available audio tracks for the active mpv player."""
+    return await _queue_mpv_command(request, "cycle_audio")
+
+
 @router.post("/ticker")
 async def show_ticker(request: Request):
     data = await request.json()

--- a/fs42/pi/remote_controller.py
+++ b/fs42/pi/remote_controller.py
@@ -45,6 +45,9 @@ KEY_MAPPINGS = {
     'channel_down': 'down',      # Previous channel
     'last_channel': 'backspace', # Switch to last channel
     'mute': 'm',                 # Mute/unmute volume
+    'toggle_subtitles': 'v',      # Toggle subtitle visibility in mpv
+    'cycle_subtitles': 'j',       # Cycle subtitle tracks in mpv
+    'cycle_audio': 'a',           # Cycle audio tracks in mpv
     'power_stop': 'end',         # Stop player (power button)
     'exit': 'esc',               # Exit remote controller
 
@@ -553,6 +556,12 @@ def handle_key_name(key_name):
                 volume_down_pressed()
             elif function_name == 'mute':
                 mute_pressed()
+            elif function_name == 'toggle_subtitles':
+                mpv_command_pressed('toggle_subtitles')
+            elif function_name == 'cycle_subtitles':
+                mpv_command_pressed('cycle_subtitles')
+            elif function_name == 'cycle_audio':
+                mpv_command_pressed('cycle_audio')
             elif function_name == 'channel_up':
                 channel_up_pressed()
             elif function_name == 'channel_down':
@@ -762,6 +771,27 @@ Environment variables:
             print(f"Error: {e}")
             sys.exit(1)
 
+
+
+def mpv_command_pressed(action):
+    """Send a non-interrupting mpv runtime command to FS42."""
+    if not should_allow_press(action):
+        return
+
+    endpoint = action.replace("_", "-")
+
+    try:
+        response = requests.post(
+            f'{FS42_BASE_URL}/player/mpv/{endpoint}',
+            timeout=2
+        )
+
+        if response.ok:
+            print(f"MPV command sent: {action}")
+        else:
+            print(f"MPV command failed: {action} ({response.status_code})")
+    except Exception as e:
+        print(f"MPV command error for {action}: {e}")
 
 if __name__ == "__main__":
     main()

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -81,6 +81,12 @@ class PlayerOutcome:
 
 
 class StationPlayer:
+    MPV_RUNTIME_COMMANDS = {
+        "toggle_subtitles": ("cycle", "sub-visibility"),
+        "cycle_subtitles": ("cycle", "sub"),
+        "cycle_audio": ("cycle", "audio"),
+    }
+
     scramble_effects = {
         "horizontal_line": "lavfi=[geq='if(mod(floor(Y/4),2),p(X,Y+20*sin(2*PI*X/50)),p(X,Y))']",
         "diagonal_lines": "lavfi=[geq='p(X+10*sin(2*PI*Y/30),Y)']",
@@ -198,6 +204,35 @@ class StationPlayer:
 
     def show_text(self, text, duration=4):
         self.mpv.command("show-text", text, duration)
+
+    def mpv_runtime_command(self, action):
+        """Run a small set of user-facing mpv runtime commands."""
+        mpv_command = self.MPV_RUNTIME_COMMANDS.get(action)
+        if not mpv_command:
+            self._l.warning(f"Unknown mpv runtime command: {action}")
+            return False
+
+        try:
+            self.mpv.command(*mpv_command)
+            self._l.info(f"Ran mpv runtime command: {action}")
+            return True
+        except Exception as e:
+            self._l.warning(f"Failed to run mpv runtime command {action}: {e}")
+            return False
+
+    def handle_runtime_command_outcome(self, response):
+        """Handle non-interrupting player commands and continue playback."""
+        if (
+            response
+            and response.status == PlayerState.SUCCESS
+            and isinstance(response.payload, str)
+            and response.payload.startswith("mpv_command:")
+        ):
+            action = response.payload.split(":", 1)[1]
+            self.mpv_runtime_command(action)
+            return True
+
+        return False
 
     def _close_now_playing(self):
         # terminate the Now Playing overlay if it's running
@@ -429,6 +464,8 @@ class StationPlayer:
             time.sleep(0.05)
             response = self.input_check_fn()
             if response:
+                if self.handle_runtime_command_outcome(response):
+                    continue
                 self._close_now_playing()
                 return response
 
@@ -594,6 +631,8 @@ class StationPlayer:
             time.sleep(0.05)
             response = self.input_check_fn()
             if response:
+                if self.handle_runtime_command_outcome(response):
+                    continue
                 self._l.info("Sending the guide channel shutdown command")
                 queue.put(GuideCommands.hide_window)
                 guide_process.join()
@@ -670,6 +709,8 @@ class StationPlayer:
             response = self.input_check_fn()
             if response:
                 # Check if this is a web_key command - forward to web process
+                if self.handle_runtime_command_outcome(response):
+                    continue
                 if response.payload and isinstance(response.payload, str) and response.payload.startswith("web_key:"):
                     key_name = response.payload[8:]
                     if self.web_queue:
@@ -817,6 +858,8 @@ class StationPlayer:
                             time.sleep(0.05)
                             response = self.input_check_fn()
                             if response:
+                                if self.handle_runtime_command_outcome(response):
+                                    continue
                                 if response.status == PlayerState.CHANNEL_CHANGE and self.web_process:
                                     try:
                                         self.web_queue.put("hide_window")


### PR DESCRIPTION
This PR adds FS42-level runtime commands for common mpv audio and subtitle actions.

FS42 starts mpv with default input bindings disabled, so normal mpv keyboard shortcuts such as `v`, to turn subtitles off, `j`, to cycle through subtitle tracks/languages, or audio-cycle/audio language shortcuts do not work while media is playing through `field_player.py`. Turning subtitles on/off, changing the audio track/language, or changing the subtitle track are built-in mpv features that a FS42 user might want to take advantage of.

This change adds explicit player commands that route through FS42’s existing command queue and call mpv directly.

## New endpoints

Adds:

```text
GET/POST /player/mpv/toggle-subtitles
GET/POST /player/mpv/cycle-subtitles
GET/POST /player/mpv/cycle-audio
```

These map to the following mpv commands:

```text
toggle-subtitles - cycle sub-visibility
cycle-subtitles  - cycle sub
cycle-audio      - cycle audio
```

## Remote mappings

Adds default remote-controller mappings:

```text
v - toggle subtitle visibility
j - cycle subtitle tracks
a - cycle audio tracks
```
(I mapped cycling audio to `a` because the original mpv keybinding is `Shift+3`, this seemed easier)
Tested by sending:

```bash
curl -X POST http://127.0.0.1:4242/player/mpv/toggle-subtitles
curl -X POST http://127.0.0.1:4242/player/mpv/cycle-subtitles
curl -X POST http://127.0.0.1:4242/player/mpv/cycle-audio
```

Confirmed that subtitle visibility toggles, subtitle tracks cycle, and audio tracks cycle during active playback when the current media has the relevant tracks available. Works with remote controller also. Keeps mpv keyboard bindings disabled and instead exposes a controlled FS42-level command path, even though I used some of the same keybindings from mpv. This preserves the existing player design while adding useful media controls for files with subtitles, alternate audio tracks, commentary tracks, or multiple language tracks.