### PR TITLE
Fix crash-y logging when optional QtWebEngine import fails

### DIFF
--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -15,14 +15,15 @@ from python_mpv_jsonipc import MPV
 from fs42.guide_tk import guide_channel_runner, GuideCommands
 from fs42.autobump_agent import AutoBumpAgent
 
-# Try to import web_render_runner, but handle gracefully if PySide6 isn't available
+# Try to import web_render_runner, but handle gracefully if PySide6 (with QtWebEngine)
+# isn't available -- web rendering is an optional feature.
 try:
-    logging.getLogger().warning("Attempting PySide Import:")
     from fs42.webrender.web_render import web_render_runner
     WEB_RENDER_AVAILABLE = True
 except ImportError as e:
-    logging.getLogger().exception("ERROR LOADING PYSIDE", e)
-
+    logging.getLogger("station_player").info(
+        "Web rendering disabled (PySide6 QtWebEngine not available): %s", e
+    )
     WEB_RENDER_AVAILABLE = False
     web_render_runner = None
 


### PR DESCRIPTION

## What

`fs42/station_player.py` guards the optional `web_render_runner` import in a
`try/except ImportError`. The except handler is malformed:

```python
except ImportError as e:
    logging.getLogger().exception("ERROR LOADING PYSIDE", e)
```

`Logger.exception(msg, *args)` treats `e` as a `%`-format argument, so on every
startup where QtWebEngine isn't installed it raises, inside logging:

```
--- Logging error ---
...
TypeError: not all arguments converted during string formatting
```

It also logs a full ERROR-level traceback for what is an *expected* optional
dependency being absent, plus an unconditional `warning("Attempting PySide Import:")`
on every launch.

## Change

```python
try:
    from fs42.webrender.web_render import web_render_runner
    WEB_RENDER_AVAILABLE = True
except ImportError as e:
    logging.getLogger("station_player").info(
        "Web rendering disabled (PySide6 QtWebEngine not available): %s", e
    )
    WEB_RENDER_AVAILABLE = False
    web_render_runner = None
```

* Fixes the `TypeError` (proper `%s` formatting).
* Downgrades to `info` — a missing optional feature isn't an error.
* Drops the unconditional "Attempting PySide Import:" warning.
* Behaviour is otherwise unchanged (`WEB_RENDER_AVAILABLE` / `web_render_runner`).

## How to reproduce the original

Run `field_player.py` in an environment where `PySide6.QtWebEngineWidgets` isn't
importable (e.g. PySide6 built without QtWebEngine, or not installed). The old code
prints the logging-error traceback above on startup.
