### PR TITLE
Add remote audio and subtitle controls

### DIFF
--- a/fs42/fs42_server/static/remote.html
+++ b/fs42/fs42_server/static/remote.html
@@ -65,6 +65,10 @@
             <button class="remote-btn function-btn" data-key="exit">EXIT</button>
             <button class="remote-btn function-btn" data-key="mute">MUTE</button>
             <button class="remote-btn function-btn" data-key="info">INFO</button>
+            <!-- Cycle MPV tracks without changing channel playback. The player shows
+                 the selected audio/subtitle track on MPV's on-screen display. -->
+            <button class="remote-btn function-btn" data-key="subtitles">SUBS</button>
+            <button class="remote-btn function-btn" data-key="audio">AUDIO</button>
         </div>
     </div>
 
@@ -427,6 +431,29 @@
                     break;
                 case 'info':
                     toggleInfoMode();
+                    break;
+                case 'subtitles':
+                    try {
+                        // Queue a non-interrupting MPV command; station_player.py
+                        // cycles the selected subtitle track and displays its label.
+                        await window.fs42Api.post('player/mpv/cycle-subtitles');
+                        display.textContent = 'SUBTITLES';
+                        console.log('Cycle subtitles command sent');
+                    } catch (error) {
+                        console.error('Cycle subtitles failed:', error);
+                        display.textContent = 'ERROR';
+                    }
+                    break;
+                case 'audio':
+                    try {
+                        // Same path as subtitles, but cycling the active audio track.
+                        await window.fs42Api.post('player/mpv/cycle-audio');
+                        display.textContent = 'AUDIO';
+                        console.log('Cycle audio command sent');
+                    } catch (error) {
+                        console.error('Cycle audio failed:', error);
+                        display.textContent = 'ERROR';
+                    }
                     break;
                 default:
                     display.textContent = key.toUpperCase();

--- a/fs42/remote/static/index.html
+++ b/fs42/remote/static/index.html
@@ -25,6 +25,13 @@
 
   <div id="entry">_</div>
 
+  <!-- Audio/subtitle controls call the main FS42 API directly so this
+       older standalone remote gets the same MPV track-cycling behaviour. -->
+  <div class="av-controls">
+    <button class="btn av-btn" onclick="sendMpvCommand('cycle-subtitles', 'SUBS')">SUBS</button>
+    <button class="btn av-btn" onclick="sendMpvCommand('cycle-audio', 'AUDIO')">AUDIO</button>
+  </div>
+
   <div class="keypad">
     <button class="btn" onclick="appendDigit(1)">1</button>
     <button class="btn" onclick="appendDigit(2)">2</button>

--- a/fs42/remote/static/remote.css
+++ b/fs42/remote/static/remote.css
@@ -109,3 +109,20 @@ html, body {
     margin-left: auto;
     margin-right: auto;
   }
+.av-controls {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  max-width: 300px;
+  margin: 0 auto 5px auto;
+}
+
+.av-controls .av-btn {
+  width: calc(50% - 10px);
+  box-sizing: border-box;
+  background: #2d4059;
+}
+
+.av-controls .av-btn:hover {
+  background: #3f5f85;
+}

--- a/fs42/remote/static/remote.js
+++ b/fs42/remote/static/remote.js
@@ -13,6 +13,24 @@ function sendCommand(cmd) {
     });
 }
 
+function sendMpvCommand(action, label) {
+  // The legacy remote may be served from a different port, but the
+  // player API lives on 4242. Keep these calls aligned with /remote.
+  const apiBase = `${window.location.protocol}//${window.location.hostname}:4242`;
+  fetch(`${apiBase}/player/mpv/${action}`, { method: "POST" })
+    .then(res => res.json())
+    .then(data => {
+      console.log("Sent MPV command:", action, data);
+      document.getElementById("entry").innerText = label;
+      setTimeout(() => { document.getElementById("entry").innerText = "_"; }, 1200);
+    })
+    .catch(err => {
+      console.error("MPV command failed:", action, err);
+      document.getElementById("entry").innerText = "ERR";
+      setTimeout(() => { document.getElementById("entry").innerText = "_"; }, 1200);
+    });
+}
+
 function appendDigit(n) {
   if (entryBuffer.length >= 2) entryBuffer = "";
   entryBuffer += n.toString();

--- a/fs42/sequence_api.py
+++ b/fs42/sequence_api.py
@@ -189,7 +189,23 @@ class SequenceAPI:
 
     @staticmethod
     def scan_sequences(station_config):
+        # A station schedule can contain the same sequenced slot many times
+        # across hours/days/templates. Building the same random_show sequence
+        # repeatedly is very expensive on large SMB media libraries, so scan
+        # each distinct sequence/tag definition once.
+        seen_slots = set()
         for slot in SequenceAPI._sequence_slots(station_config):
+            key = (
+                slot.get("sequence"),
+                repr(slot.get("tags")),
+                slot.get("sequence_strategy"),
+                repr(slot.get("sequence_id_array")),
+                slot.get("sequence_start"),
+                slot.get("sequence_end"),
+            )
+            if key in seen_slots:
+                continue
+            seen_slots.add(key)
             SequenceAPI._scan_sequence_slot(station_config, slot)
 
     @staticmethod

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -6,6 +6,7 @@ import time
 import datetime
 import json
 import os
+import re
 import glob
 import random
 import logging
@@ -181,6 +182,13 @@ class StationPlayer:
                 force_window=True,
                 script_opts="osc-idlescreen=no",
                 hr_seek="yes",
+                # Prefer English audio. Keep subtitles off by default, but play_file()
+                # will turn English subtitles on for files with no English audio.
+                alang="eng,en,English",
+                slang="eng,en,English",
+                sub_auto="fuzzy",
+                sid="no",
+                sub_visibility=False,
             )
 
         self.station_config = station_config
@@ -207,6 +215,76 @@ class StationPlayer:
     def show_text(self, text, duration=4):
         self.mpv.command("show-text", text, duration)
 
+    def _track_label(self, track):
+        """Return a compact human-readable label for an MPV track-list item."""
+        if not track:
+            return "Off"
+
+        parts = []
+        lang = track.get("lang") or track.get("language")
+        title = track.get("title")
+        codec = track.get("codec") or track.get("codec-desc")
+
+        if lang:
+            parts.append(str(lang).upper())
+        if title and str(title).lower() not in [str(p).lower() for p in parts]:
+            parts.append(str(title))
+        if codec and not title:
+            parts.append(str(codec))
+
+        label = " - ".join(parts).strip()
+        if not label:
+            label = f"Track {track.get('id', '?')}"
+        return label
+
+    def _selected_track(self, track_type):
+        """Return the currently-selected MPV track of type 'audio' or 'sub'."""
+        try:
+            tracks = self.mpv.command("get_property", "track-list") or []
+        except Exception as e:
+            self._l.warning(f"Could not read MPV track list for OSD: {e}")
+            return None
+
+        for track in tracks:
+            if track.get("type") == track_type and track.get("selected"):
+                return track
+        return None
+
+    def _show_track_selection_osd(self, action):
+        """Show the current audio/subtitle selection after a remote button press."""
+        try:
+            if action in ("toggle_subtitles", "cycle_subtitles"):
+                selected = self._selected_track("sub")
+                sid = self.mpv.command("get_property", "sid")
+                visible = self.mpv.command("get_property", "sub-visibility")
+
+                # Cycling to a real subtitle track should make it visible; cycling to
+                # no subtitle should hide subtitles. This keeps the SUBS button useful
+                # when subtitles were hidden by the English-audio default.
+                if action == "cycle_subtitles":
+                    if selected and sid not in (None, "no", False):
+                        self.mpv.command("set_property", "sub-visibility", True)
+                        visible = True
+                    else:
+                        self.mpv.command("set_property", "sub-visibility", False)
+                        visible = False
+
+                if selected and visible and sid not in (None, "no", False):
+                    message = f"Subtitles: {self._track_label(selected)}"
+                else:
+                    message = "Subtitles: Off"
+
+            elif action == "cycle_audio":
+                selected = self._selected_track("audio")
+                message = f"Audio: {self._track_label(selected)}"
+            else:
+                return
+
+            self.show_text(message, 2500)
+            self._l.info(f"OSD track selection: {message}")
+        except Exception as e:
+            self._l.warning(f"Failed to show track selection OSD for {action}: {e}")
+
     def mpv_runtime_command(self, action):
         """Run a small set of user-facing mpv runtime commands."""
         mpv_command = self.MPV_RUNTIME_COMMANDS.get(action)
@@ -216,6 +294,9 @@ class StationPlayer:
 
         try:
             self.mpv.command(*mpv_command)
+            # After MPV mutates track state, read back the selected track and
+            # show it on the TV so remote users get immediate feedback.
+            self._show_track_selection_osd(action)
             self._l.info(f"Ran mpv runtime command: {action}")
             return True
         except Exception as e:
@@ -327,6 +408,59 @@ class StationPlayer:
             else:
                 self.mpv.vf = self.reception.filter()
 
+
+
+    ENGLISH_LANGS = {"eng", "en", "english"}
+
+    def _track_is_english(self, track):
+        """Return True when an MPV track is clearly marked as English."""
+        values = []
+        for key in ("lang", "title"):
+            val = track.get(key)
+            if val:
+                values.append(str(val).lower())
+        text = " ".join(values)
+        return any(re.search(rf"(^|[^a-z]){re.escape(lang)}([^a-z]|$)", text) for lang in self.ENGLISH_LANGS)
+
+    def _configure_language_tracks(self, file_path, is_stream=False):
+        """Prefer English audio, but enable English subtitles when no English audio exists.
+
+        This is intentionally conservative for foreign-language films: if a file
+        has no track explicitly marked English (including unlabelled audio) and
+        MPV sees an English subtitle track/sidecar, show that subtitle track.
+        Otherwise keep subtitles hidden so ordinary English playback stays clean.
+        """
+        if is_stream or AutoBumpAgent.is_autobump_url(file_path):
+            return
+        try:
+            tracks = self.mpv.command("get_property", "track-list") or []
+            audio_tracks = [t for t in tracks if t.get("type") == "audio"]
+            sub_tracks = [t for t in tracks if t.get("type") == "sub"]
+            english_audio = [t for t in audio_tracks if self._track_is_english(t)]
+            english_subs = [t for t in sub_tracks if self._track_is_english(t)]
+
+            if english_audio:
+                self.mpv.command("set_property", "sid", "no")
+                self.mpv.command("set_property", "sub-visibility", False)
+                self._l.info("English audio available; subtitles disabled")
+                return
+
+            if english_subs:
+                chosen = english_subs[0]
+                self.mpv.command("set_property", "sid", chosen.get("id"))
+                self.mpv.command("set_property", "sub-visibility", True)
+                self._l.info(
+                    f"No English audio detected; enabled English subtitles: "
+                    f"id={chosen.get('id')} lang={chosen.get('lang')} title={chosen.get('title')}"
+                )
+                return
+
+            self.mpv.command("set_property", "sid", "no")
+            self.mpv.command("set_property", "sub-visibility", False)
+            self._l.info("No English audio or English subtitles detected; subtitles disabled")
+        except Exception as e:
+            self._l.warning(f"Could not configure audio/subtitle language tracks for {file_path}: {e}")
+
     def play_file(self, file_path, file_duration=None, offset_seconds=None, is_stream=False, title="Unknown", content_type=None, media_type=None):
         try:
             if os.path.exists(file_path) or is_stream or AutoBumpAgent.is_autobump_url(file_path):
@@ -418,6 +552,8 @@ class StationPlayer:
                             self._l.error(f"Error waiting for playback: {e}")
                             return False
                         time.sleep(0.05)
+
+                self._configure_language_tracks(file_path, is_stream=is_stream)
 
                 # Perform seek if needed (before showing overlay)
                 if not is_stream and offset_seconds is not None and offset_seconds > 0:


### PR DESCRIPTION
## Summary
- add SUBS and AUDIO buttons to the FS42 web remotes
- route buttons through MPV runtime commands for cycling subtitle/audio tracks
- show the current audio/subtitle selection on MPV OSD after each change
- prefer English audio and automatically enable English subtitles when no English audio is detected
- avoid duplicate sequence scans for repeated schedule slots

## Testing
- python3 -m py_compile fs42/station_player.py fs42/sequence_api.py
- verified live endpoints on FS42: POST /player/mpv/cycle-subtitles and POST /player/mpv/cycle-audio
