### PR TITLE
Add web remote buttons for audio and subtitle cycling

### DIFF
--- a/fs42/fs42_server/static/remote.html
+++ b/fs42/fs42_server/static/remote.html
@@ -65,6 +65,10 @@
             <button class="remote-btn function-btn" data-key="exit">EXIT</button>
             <button class="remote-btn function-btn" data-key="mute">MUTE</button>
             <button class="remote-btn function-btn" data-key="info">INFO</button>
+            <!-- Cycle MPV tracks without changing channel playback. The player shows
+                 the selected audio/subtitle track on MPV's on-screen display. -->
+            <button class="remote-btn function-btn" data-key="subtitles">SUBS</button>
+            <button class="remote-btn function-btn" data-key="audio">AUDIO</button>
         </div>
     </div>
 
@@ -427,6 +431,29 @@
                     break;
                 case 'info':
                     toggleInfoMode();
+                    break;
+                case 'subtitles':
+                    try {
+                        // Queue a non-interrupting MPV command; station_player.py
+                        // cycles the selected subtitle track and displays its label.
+                        await window.fs42Api.post('player/mpv/cycle-subtitles');
+                        display.textContent = 'SUBTITLES';
+                        console.log('Cycle subtitles command sent');
+                    } catch (error) {
+                        console.error('Cycle subtitles failed:', error);
+                        display.textContent = 'ERROR';
+                    }
+                    break;
+                case 'audio':
+                    try {
+                        // Same path as subtitles, but cycling the active audio track.
+                        await window.fs42Api.post('player/mpv/cycle-audio');
+                        display.textContent = 'AUDIO';
+                        console.log('Cycle audio command sent');
+                    } catch (error) {
+                        console.error('Cycle audio failed:', error);
+                        display.textContent = 'ERROR';
+                    }
                     break;
                 default:
                     display.textContent = key.toUpperCase();


### PR DESCRIPTION
## Summary

Adds `SUBS` and `AUDIO` buttons to the built-in FS42 web remote.

The buttons use the existing mpv control endpoints to cycle subtitle and audio tracks on the currently playing item:

- `POST /player/mpv/cycle-subtitles`
- `POST /player/mpv/cycle-audio`

I’ve kept this deliberately small after the previous PR feedback. This only updates `fs42/fs42_server/static/remote.html`; it does not change playback defaults, language preference logic, `play_file()`, sequence scanning, or the separate legacy remote app.

## Testing

Ran:

```bash
python3 -m py_compile fs42/fs42_server/api/player.py
```

Also checked the remote HTML for the new buttons and endpoint calls.
