### PR TITLE
Keep manual audio and subtitle choices within the current programme

### DIFF
--- a/fs42/fs42_server/static/remote.html
+++ b/fs42/fs42_server/static/remote.html
@@ -65,6 +65,10 @@
             <button class="remote-btn function-btn" data-key="exit">EXIT</button>
             <button class="remote-btn function-btn" data-key="mute">MUTE</button>
             <button class="remote-btn function-btn" data-key="info">INFO</button>
+            <!-- Cycle MPV tracks without changing channel playback. The player shows
+                 the selected audio/subtitle track on MPV's on-screen display. -->
+            <button class="remote-btn function-btn" data-key="subtitles">SUBS</button>
+            <button class="remote-btn function-btn" data-key="audio">AUDIO</button>
         </div>
     </div>
 
@@ -427,6 +431,29 @@
                     break;
                 case 'info':
                     toggleInfoMode();
+                    break;
+                case 'subtitles':
+                    try {
+                        // Queue a non-interrupting MPV command; station_player.py
+                        // cycles the selected subtitle track and displays its label.
+                        await window.fs42Api.post('player/mpv/cycle-subtitles');
+                        display.textContent = 'SUBTITLES';
+                        console.log('Cycle subtitles command sent');
+                    } catch (error) {
+                        console.error('Cycle subtitles failed:', error);
+                        display.textContent = 'ERROR';
+                    }
+                    break;
+                case 'audio':
+                    try {
+                        // Same path as subtitles, but cycling the active audio track.
+                        await window.fs42Api.post('player/mpv/cycle-audio');
+                        display.textContent = 'AUDIO';
+                        console.log('Cycle audio command sent');
+                    } catch (error) {
+                        console.error('Cycle audio failed:', error);
+                        display.textContent = 'ERROR';
+                    }
                     break;
                 default:
                     display.textContent = key.toUpperCase();

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -182,6 +182,8 @@ class StationPlayer:
                 script_opts="osc-idlescreen=no",
                 hr_seek="yes",
             )
+        else:
+            self.mpv = mpv
 
         self.station_config = station_config
         # self.playlist = self.read_json(runtime_filepath)
@@ -197,6 +199,12 @@ class StationPlayer:
         self.schedule_lock = None
         self._active_afx = None
         self._pending_response = None
+        self._track_preference_block = None
+        self._preferred_audio_track_index = None
+        self._preferred_subtitle_track_index = None
+        self._preferred_subtitle_visibility = None
+        self._current_content_type = None
+        self._current_media_type = None
 
     def load_up(self):
         start_time = time.perf_counter()
@@ -207,6 +215,94 @@ class StationPlayer:
     def show_text(self, text, duration=4):
         self.mpv.command("show-text", text, duration)
 
+    def _set_track_preference_block(self, block_title):
+        """Clear manual track preferences when the scheduled programme changes."""
+        if block_title != self._track_preference_block:
+            self._track_preference_block = block_title
+            self._preferred_audio_track_index = None
+            self._preferred_subtitle_track_index = None
+            self._preferred_subtitle_visibility = None
+
+    def _track_list(self):
+        try:
+            tracks = getattr(self.mpv, "track_list")
+        except Exception:
+            tracks = None
+
+        if tracks is None:
+            try:
+                tracks = self.mpv.command("get_property", "track-list")
+            except Exception as e:
+                self._l.debug(f"Could not read mpv track-list: {e}")
+                return []
+
+        return tracks or []
+
+    def _tracks_of_type(self, track_type):
+        return [track for track in self._track_list() if track.get("type") == track_type]
+
+    @staticmethod
+    def _track_is_selected(track):
+        return track.get("selected") or track.get("selected?")
+
+    def _selected_track_index(self, track_type):
+        tracks = self._tracks_of_type(track_type)
+        for index, track in enumerate(tracks):
+            if self._track_is_selected(track):
+                return index
+        return None
+
+    def _track_id_at_index(self, track_type, index):
+        tracks = self._tracks_of_type(track_type)
+        if index is None or index < 0 or index >= len(tracks):
+            return None
+        return tracks[index].get("id")
+
+    def _set_mpv_property(self, name, value):
+        try:
+            setattr(self.mpv, name.replace("-", "_"), value)
+        except Exception:
+            self.mpv.command("set_property", name, value)
+
+    def _remember_runtime_track_preference(self, action):
+        """Remember manual AV choices made while the feature itself is playing."""
+        if self._current_content_type != "feature" or self._current_media_type != "video":
+            return
+
+        if action == "cycle_audio":
+            self._preferred_audio_track_index = self._selected_track_index("audio")
+        elif action == "cycle_subtitles":
+            self._preferred_subtitle_track_index = self._selected_track_index("sub")
+            try:
+                self._preferred_subtitle_visibility = bool(getattr(self.mpv, "sub_visibility"))
+            except Exception:
+                self._preferred_subtitle_visibility = True
+
+    def _apply_runtime_track_preferences(self, content_type=None, media_type=None):
+        """Reapply block-scoped manual AV choices when the same feature resumes."""
+        if content_type != "feature" or media_type != "video":
+            return
+
+        audio_id = self._track_id_at_index("audio", self._preferred_audio_track_index)
+        if audio_id is not None:
+            try:
+                self._set_mpv_property("audio", audio_id)
+            except Exception as e:
+                self._l.debug(f"Could not reapply audio track preference: {e}")
+
+        subtitle_id = self._track_id_at_index("sub", self._preferred_subtitle_track_index)
+        if subtitle_id is not None:
+            try:
+                self._set_mpv_property("sub", subtitle_id)
+            except Exception as e:
+                self._l.debug(f"Could not reapply subtitle track preference: {e}")
+
+        if self._preferred_subtitle_visibility is not None:
+            try:
+                self._set_mpv_property("sub-visibility", self._preferred_subtitle_visibility)
+            except Exception as e:
+                self._l.debug(f"Could not reapply subtitle visibility preference: {e}")
+
     def mpv_runtime_command(self, action):
         """Run a small set of user-facing mpv runtime commands."""
         mpv_command = self.MPV_RUNTIME_COMMANDS.get(action)
@@ -216,6 +312,7 @@ class StationPlayer:
 
         try:
             self.mpv.command(*mpv_command)
+            self._remember_runtime_track_preference(action)
             self._l.info(f"Ran mpv runtime command: {action}")
             return True
         except Exception as e:
@@ -341,6 +438,8 @@ class StationPlayer:
             if os.path.exists(file_path) or is_stream or AutoBumpAgent.is_autobump_url(file_path):
                 self._l.debug(f"%%%Attempting to play {file_path}")
                 self.current_playing_file_path = file_path
+                self._current_content_type = content_type
+                self._current_media_type = media_type
 
                 if self.station_config:
                     self._l.debug("Got station config, updating status socket")
@@ -427,6 +526,8 @@ class StationPlayer:
                             self._l.error(f"Error waiting for playback: {e}")
                             return False
                         time.sleep(0.05)
+
+                self._apply_runtime_track_preferences(content_type, media_type)
 
                 # Perform seek if needed (before showing overlay)
                 if not is_stream and offset_seconds is not None and offset_seconds > 0:
@@ -834,6 +935,7 @@ class StationPlayer:
         # Close any existing now playing overlay when starting a new play point
         # This handles channel changes and ensures clean state
         self._close_now_playing()
+        self._set_track_preference_block(play_point.block_title)
 
         if len(play_point.plan):
             initial_skip = play_point.offset

--- a/test/test_station_player_track_preferences.py
+++ b/test/test_station_player_track_preferences.py
@@ -1,0 +1,122 @@
+from fs42.station_player import StationPlayer
+
+
+class FakeMPV:
+    def __init__(self):
+        self.track_list = [
+            {"type": "audio", "id": 1, "selected": True},
+            {"type": "audio", "id": 2, "selected": False},
+            {"type": "sub", "id": 3, "selected": False},
+            {"type": "sub", "id": 4, "selected": True},
+        ]
+        self.audio = 1
+        self.sub = 4
+        self.sub_visibility = True
+        self.commands = []
+
+    def command(self, *args):
+        self.commands.append(args)
+        if args == ("cycle", "audio"):
+            self._cycle("audio")
+            return None
+        if args == ("cycle", "sub"):
+            self._cycle("sub")
+            self.sub_visibility = self._selected("sub") is not None
+            return None
+        raise AssertionError(f"unexpected command: {args}")
+
+    def _selected(self, track_type):
+        for track in self.track_list:
+            if track["type"] == track_type and track.get("selected"):
+                return track
+        return None
+
+    def _cycle(self, track_type):
+        tracks = [track for track in self.track_list if track["type"] == track_type]
+        selected = self._selected(track_type)
+        next_index = 0
+        if selected in tracks:
+            next_index = (tracks.index(selected) + 1) % len(tracks)
+            selected["selected"] = False
+        tracks[next_index]["selected"] = True
+        if track_type == "audio":
+            self.audio = tracks[next_index]["id"]
+        else:
+            self.sub = tracks[next_index]["id"]
+
+
+def make_player():
+    return StationPlayer({}, lambda: None, mpv=FakeMPV())
+
+
+def test_audio_choice_is_remembered_by_track_position_for_feature_video():
+    player = make_player()
+    player._current_content_type = "feature"
+    player._current_media_type = "video"
+
+    assert player.mpv.audio == 1
+    assert player.mpv_runtime_command("cycle_audio") is True
+
+    assert player.mpv.audio == 2
+    assert player._preferred_audio_track_index == 1
+
+
+def test_subtitle_choice_is_remembered_with_visibility_for_feature_video():
+    player = make_player()
+    player._current_content_type = "feature"
+    player._current_media_type = "video"
+
+    assert player.mpv.sub == 4
+    assert player.mpv_runtime_command("cycle_subtitles") is True
+
+    assert player.mpv.sub == 3
+    assert player._preferred_subtitle_track_index == 0
+    assert player._preferred_subtitle_visibility is True
+
+
+def test_choices_made_during_commercial_are_not_remembered():
+    player = make_player()
+    player._current_content_type = "commercial"
+    player._current_media_type = "video"
+
+    assert player.mpv_runtime_command("cycle_audio") is True
+
+    assert player._preferred_audio_track_index is None
+
+
+def test_track_preferences_only_apply_to_feature_video():
+    player = make_player()
+    player._preferred_audio_track_index = 1
+    player._preferred_subtitle_track_index = 0
+    player._preferred_subtitle_visibility = True
+
+    player._apply_runtime_track_preferences("commercial", "video")
+
+    assert player.mpv.audio == 1
+    assert player.mpv.sub == 4
+
+    player._apply_runtime_track_preferences("feature", "video")
+
+    assert player.mpv.audio == 2
+    assert player.mpv.sub == 3
+    assert player.mpv.sub_visibility is True
+
+
+def test_preferences_clear_when_programme_block_changes():
+    player = make_player()
+    player._set_track_preference_block("Movie A")
+    player._preferred_audio_track_index = 1
+    player._preferred_subtitle_track_index = 0
+    player._preferred_subtitle_visibility = True
+
+    player._set_track_preference_block("Movie A")
+
+    assert player._preferred_audio_track_index == 1
+    assert player._preferred_subtitle_track_index == 0
+    assert player._preferred_subtitle_visibility is True
+
+    player._set_track_preference_block("Movie B")
+
+    assert player._preferred_audio_track_index is None
+    assert player._preferred_subtitle_track_index is None
+    assert player._preferred_subtitle_visibility is None


### PR DESCRIPTION
## Summary

Follow-up to #641. This keeps remote-control audio/subtitle selections local to the currently playing scheduled programme block, so a viewer's manual choice survives bumpers/commercials and is cleared when the next programme starts.

## Behaviour

- remembers `AUDIO` / `SUBS` button choices only while a `feature` video is playing
- reapplies the remembered selection if the same programme block resumes after interstitials
- clears remembered selections when playback enters a new programme block
- does not persist choices to disk/config
- does not attempt language detection
- does not apply the programme choice to commercials/bumpers

## Notes

This is intentionally marked as a draft because it is stacked on top of #641. Until #641 is merged, GitHub will show both the remote-button commit and this follow-up commit in this PR.

## Testing

```bash
python3 -m py_compile fs42/station_player.py fs42/fs42_server/api/player.py
python3 -m pytest test/test_station_player_track_preferences.py test/test_nfo_agent.py -q
```

Result:

```text
28 passed
```
