### PR TITLE
title_parser: preserve dots, inner hyphens, roman numerals, acronyms

### DIFF
--- a/fs42/title_parser.py
+++ b/fs42/title_parser.py
@@ -1,8 +1,73 @@
 import re
-from pathlib import Path
 
 
 class TitleParser:
+    # Path().stem and os.path.splitext() split at the LAST dot, which eats title
+    # text in names like "G.I. Joe" or "C.O.P.S". Callers already strip the
+    # extension, so match only real video extensions -- this is idempotent and
+    # safe to apply twice.
+    VIDEO_EXT = re.compile(
+        r"\.(mp4|mkv|avi|mov|m4v|webm|wmv|flv|mpg|mpeg|ts|m2ts|ogv|divx|vob)$", re.I
+    )
+    # Dotted acronyms: G.I. / C.O.P.S / S.W.A.T.
+    ACRONYM = re.compile(r"(?<![A-Za-z0-9])(?:[A-Za-z]\.){2,}[A-Za-z]?(?![A-Za-z0-9])")
+    # Single-dot abbreviations the acronym rule is too strict to catch
+    ABBREV = re.compile(r"\b(Mr|Mrs|Ms|Dr|St|Jr|Sr|Lt|Sgt|Capt|Prof|Gen|Col)\.", re.I)
+    # Hyphen welded between two word chars: He-Man, Spider-Man.
+    # Spaced separators (" - ") are untouched by the lookarounds.
+    INNER_DASH = re.compile(r"(?<=[A-Za-z0-9])-(?=\s|$)|(?<=[A-Za-z0-9])-(?=[A-Za-z0-9])")
+    # Strict Roman numeral form -- rejects words that merely use those letters
+    # (MID, DILL, CIVIL) while accepting II, IV, VIII, XIII.
+    ROMAN = re.compile(
+        r"^(?=[MDCLXVI])M{0,4}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:IX|IV|V?I{0,3})$"
+    )
+    # Tokens that keep their case regardless of how they appear in the filename.
+    # Compared against the token with punctuation stripped, so "(nes)" matches.
+    KEEP_UPPER = {
+        "UFC", "TMNT", "AVGN", "NES", "SNES", "SNL", "MTV", "HBO", "PBS",
+        "BBC", "CBS", "NBC", "ABC", "TV", "DVD", "VHS", "NFL", "NBA", "MLB",
+        "NHL", "WWE", "WWF", "WCW", "USA", "UK", "FBI", "CIA", "NASA",
+    }
+
+    _DOT = "\x00"
+    _DASH = "\x01"
+
+    @staticmethod
+    def _cap_part(part: str) -> str:
+        core = re.sub(r"[^A-Za-z0-9]", "", part)
+        if core and core.upper() in TitleParser.KEEP_UPPER:
+            return part.upper()
+        # Already-uppercase Roman numerals keep their case: "III" not "Iii"
+        if len(part) > 1 and part.isupper() and TitleParser.ROMAN.match(part):
+            return part
+        return part.capitalize()
+
+    @staticmethod
+    def _cap(word: str) -> str:
+        # capitalize() lowercases everything after the first char, which would
+        # turn "C.O.P.S" into "C.o.p.s" and "He-Man" into "He-man".
+        if "." in word:
+            return word
+        return "-".join(TitleParser._cap_part(p) for p in word.split("-"))
+
+    @staticmethod
+    def _clean(title: str) -> str:
+        # Shield dots and inner hyphens from the separator cleanup, then restore
+        title = TitleParser.ACRONYM.sub(
+            lambda m: m.group(0).replace(".", TitleParser._DOT), title
+        )
+        title = TitleParser.ABBREV.sub(
+            lambda m: m.group(0).replace(".", TitleParser._DOT), title
+        )
+        title = re.sub(r"(?<=[A-Za-z0-9])-(?=[A-Za-z0-9])", TitleParser._DASH, title)
+
+        title = re.sub(r"[._-]", " ", title)  # separators to spaces
+        title = re.sub(r"\s+", " ", title)  # collapse runs of whitespace
+        title = title.strip()
+
+        title = title.replace(TitleParser._DOT, ".").replace(TitleParser._DASH, "-")
+        return " ".join(TitleParser._cap(w) for w in title.split())
+
     @staticmethod
     def parse_title(in_str: str, custom_patterns: list = None) -> str:
         if not in_str:
@@ -11,7 +76,7 @@ class TitleParser:
         filename = in_str.strip()
 
         # Remove file extension
-        filename = Path(filename).stem
+        filename = TitleParser.VIDEO_EXT.sub("", filename)
 
         # Define separator pattern - spaces, dots, underscores, dashes
         sep = r"[\s._-]+"
@@ -56,15 +121,7 @@ class TitleParser:
         for pattern, group in patterns:
             match = re.match(pattern, filename)
             if match:
-                title = match.group(group)
-                # Clean up the title
-                title = re.sub(r"[._-]", " ", title)  # Replace dots, dashes and underscores with spaces
-                title = re.sub(r"\s+", " ", title)  # Normalize multiple spaces
-                title = title.strip()
-                # Convert to title case
-                return " ".join(word.capitalize() for word in title.split())
+                return TitleParser._clean(match.group(group))
 
         # Fallback: return cleaned filename
-        cleaned = re.sub(r"[._-]", " ", filename)
-        cleaned = re.sub(r"\s+", " ", cleaned).strip()
-        return " ".join(word.capitalize() for word in cleaned.split())
+        return TitleParser._clean(filename)


### PR DESCRIPTION
## Problem

`TitleParser.parse_title` calls `Path(filename).stem`, which splits at the **last** dot regardless of what follows. Callers in `catalog_entry.py:21` and `media_processor.py:112` already strip the extension via `os.path.splitext`, so `parse_title` receives a bare stem and strips a second time — consuming real title text.

```python
>>> T.parse_title('G.I. Joe - S03E12.mkv')   # extension present
'G I Joe'
>>> T.parse_title('G.I. Joe - S03E12')       # same file, post-splitext
'G I'
>>> T.parse_title('C.O.P.S - E60 The Case of the Lawless Lady')
'C O P'
```

The same show renders inconsistently within a single schedule depending on which call path reached it. Custom `title_patterns` can't work around this — the user pattern captures `G.I. Joe` correctly and the damage happens downstream, in the cleanup applied to the matched group.

Four related issues in that same cleanup, all from the assumption that filenames are scene-style dot-delimited:

| Input | Before | After |
|---|---|---|
| `C.O.P.S - E60 ...` | `C O P` | `C.O.P.S` |
| `He-Man and the Masters of the Universe - S02E32.mkv` | `He Man And The Masters...` | `He-Man And The Masters...` |
| `The Godfather - Part III (1990).mp4` | `The Godfather Part Iii` | `The Godfather Part III` |
| `UFC 12 Judgement Day.mp4` | `Ufc 12 Judgement Day` | `UFC 12 Judgement Day` |

`re.sub(r"[._-]", " ", title)` flattens acronym dots and compound-name hyphens; `str.capitalize()` lowercases everything after the first character, which destroys both Roman numerals and all-caps show names.

## Approach

- **Extension stripping** matches only known video extensions, so it's idempotent — the existing double call becomes harmless and no caller needs changing.
- **Acronym and hyphen shielding** substitutes sentinel characters before the separator cleanup, then restores them. The hyphen rule uses lookarounds requiring word characters on both sides, so ` - ` separators are unaffected.
- **Roman numerals** use a strict form that rejects words merely composed of those letters (`MID`, `DILL`, `CIVIL` stay title-cased).
- **`KEEP_UPPER`** preserves case for a small set of known acronyms. Happy to make this config-driven via `main_config.json` if an opinionated default isn't wanted — `StationManager` already loads arbitrary keys.

`default_patterns` is byte-identical to before; the diff is confined to the cleanup path.

## Verification

Tested against a ~2,400 file library. Selected cases with custom patterns loaded:

```
'G.I. Joe - S03E12.mkv'                                    -> G.I. Joe
'G.I. Joe - S03E12'                                        -> G.I. Joe
'C.O.P.S - E48 The Case of the Lesser of Two Weevils.mp4'  -> C.O.P.S
'He-Man and the Masters of the Universe - S02E32.mkv'      -> He-Man And The Masters Of The Universe
'Spider-Man and His Amazing Friends - S01E03.mkv'          -> Spider-Man And His Amazing Friends
'The Godfather - Part III (1990).mp4'                      -> The Godfather Part III
'Menace II Society (1993).mp4'                             -> Menace II Society
'Mid (1999).mp4'                                           -> Mid
'Civil Action (1998).mp4'                                  -> Civil Action
'UFC 12 Judgement Day.mp4'                                 -> UFC 12 Judgement Day
'AVGN 042 Cheetahmen (nes).mp4'                            -> Cheetahmen (NES)
'Looney Tunes - S1952E12 Going! Going! Gosh!.mp4'          -> Looney Tunes
'Star Wars Ewoks - S01E09.mkv'                             -> Star Wars Ewoks
```

The last two confirm no regression on titles without punctuation.

This fix was created using Claude model Opus 5, so up to you if you want this change.  It's been working well for me so far.