### PR TITLE
OSD: Configurable status socket + instant channel confirm

### DIFF
--- a/fs42/osd/main.py
+++ b/fs42/osd/main.py
@@ -38,6 +38,7 @@ class VAlignment(Enum):
 
 
 class StatusDisplayConfig(BaseModel):
+    socket_file: str = SOCKET_FILE
     display_time: float = 2.0
     halign: HAlignment = HAlignment.LEFT
     valign: VAlignment = VAlignment.TOP
@@ -70,9 +71,13 @@ class StatusDisplay(object):
 
         self.check_status()
 
-    def check_status(self, socket_file=SOCKET_FILE):
+    def check_status(self, socket_file=None):
+        if socket_file is None:
+            socket_file = self.config.socket_file
         with open(socket_file, "r") as f:
             status = f.read()
+            if not status.strip():
+                return
             try:
                 status = json.loads(status)
             except:

--- a/fs42/osd/main.py
+++ b/fs42/osd/main.py
@@ -74,26 +74,31 @@ class StatusDisplay(object):
     def check_status(self, socket_file=None):
         if socket_file is None:
             socket_file = self.config.socket_file
-        with open(socket_file, "r") as f:
-            status = f.read()
-            if not status.strip():
-                return
-            try:
-                status = json.loads(status)
-            except:
-                print(f"Unable to parse player status, {status}")
+        try:
+            with open(socket_file, "r") as f:
+                status = f.read()
+        except OSError:
+            return
 
-            else:
-                # Check if status field changed (e.g., from "stopped" to "playing")
-                status_changed = self.last_status is None or status.get("status") != self.last_status.get("status")
-                self.last_status = status
+        if not status.strip():
+            return
 
-                new_string = self.config.format_text.format_map(defaultdict(str, status))
-                # Reset timer if text changed OR if status changed (like stopped->playing)
-                if new_string != self._text.string or status_changed:
-                    self.time_since_change = -self.config.delay
-                    if new_string:
-                        self._text.string = new_string
+        try:
+            status = json.loads(status)
+        except (json.JSONDecodeError, ValueError):
+            print(f"Unable to parse player status, {status}")
+            return
+
+        # Check if status field changed (e.g., from "stopped" to "playing")
+        status_changed = self.last_status is None or status.get("status") != self.last_status.get("status")
+        self.last_status = status
+
+        new_string = self.config.format_text.format_map(defaultdict(str, status))
+        # Reset timer if text changed OR if status changed (like stopped->playing)
+        if new_string != self._text.string or status_changed:
+            self.time_since_change = -self.config.delay
+            if new_string:
+                self._text.string = new_string
 
     def update(self, dt):
         self.time_since_change += dt

--- a/fs42/pi/remote_controller.py
+++ b/fs42/pi/remote_controller.py
@@ -602,6 +602,16 @@ def handle_key_event(event):
         elif key_code == ecodes.KEY_0:
             number_pressed(0)
             return True
+        elif key_code in (ecodes.KEY_ENTER, ecodes.KEY_KPENTER):
+            # Confirm channel input immediately instead of waiting for the timeout
+            global channel_input, channel_input_timer
+            with input_lock:
+                if channel_input_timer:
+                    channel_input_timer.cancel()
+                    channel_input_timer = None
+            if channel_input:
+                send_channel_change()
+            return True
 
         # Get the key name and check if it's mapped to a function
         key_name = get_key_name_from_code(key_code)

--- a/osd/examples/channel_number_entry.json
+++ b/osd/examples/channel_number_entry.json
@@ -1,0 +1,18 @@
+[
+	{
+		"halign": "LEFT",
+		"valign": "TOP",
+		"font_size": 40,
+		"text_color": [0, 255, 0, 200],
+		"format_text": "{channel_number} - {network_name}"
+	},
+	{
+		"socket_file": "runtime/press.socket",
+		"format_text": "CH {digits}",
+		"halign": "CENTER",
+		"valign": "CENTER",
+		"font_size": 90,
+		"text_color": [0, 255, 0, 220],
+		"display_time": 1.5
+	}
+]


### PR DESCRIPTION
## What this adds

**1. `StatusDisplay` can read from any socket, not just `play_status.socket`**

`StatusDisplayConfig` gets a new optional `socket_file` field (defaults to
the existing `play_status.socket`, so every current `osd.json` keeps working
unchanged). This lets a panel be pointed at any other JSON status socket,
for example `runtime/press.socket`, which `remote_controller.py` already
writes to on every digit press while a channel number is being entered.

Also guards `check_status()` against an empty socket file. `press.socket`
gets truncated back to empty once a channel change is sent, and the OSD
polls at ~30fps, so without this guard it would spam
`Unable to parse player status, ` to the log every frame while idle.

**2. Enter/KP_Enter confirms channel entry immediately**

`number_pressed()` already buffers digits and auto-submits after a ~1s
pause (or instantly once 3 digits are entered). This adds an explicit
confirm path: pressing Enter or numpad Enter cancels the pending debounce
timer and sends the channel change right away, so tuning to e.g. channel 1
or 42 does not require waiting out the full timeout.

**3. `osd/examples/channel_number_entry.json`**

New example showing the two changes together: the normal channel/network
panel plus a second panel wired to `runtime/press.socket` that displays
`CH {digits}` live while typing, then auto-hides shortly after Enter (or
the timeout) confirms the change.

## Motivation

Built this for a Flirc remote setup where number pad buttons tune channels
directly. Wanted on screen feedback while typing a multi-digit channel and
a way to confirm immediately instead of always waiting out the debounce.
Both changes are additive and backward compatible; no existing `osd.json`
or remote mapping behavior changes.

## Testing

- Verified against real hardware (Flirc remote via `evdev`) tuning to
  multiple 1-2 digit channels with both timeout-based and Enter-confirmed
  entry.
- Confirmed existing panels (no `socket_file` set) still read
  `play_status.socket` as before.
- Confirmed no log spam from the empty-socket case.
