### PR TITLE
feat: added week number and custom holiday support to schedule_hint

### DIFF
--- a/fs42/schedule_hint.py
+++ b/fs42/schedule_hint.py
@@ -83,6 +83,33 @@ class BumpHint:
     def fromJSON(json_data):
         return BumpHint(json_data["where"])
 
+class WeekNumberHint:
+    pattern = re.compile("^week number ([1-9]|[1-4][0-9]|5[0-3])$", re.IGNORECASE)
+
+    def __init__(self, week_name):
+        self.week_name = week_name
+        self.week_number = datetime
+        if WeekNumberHint.test_pattern(week_name):
+            self.week_number = int(self.week_name.lower().strip("week number"))
+        else:
+            raise ValueError(f"Week Number not valid: {week_name}- Sholud be 'week number <1-53>'")
+        self.type = "week_number"
+
+    @staticmethod
+    def test_pattern(to_test):
+        m = WeekNumberHint.pattern.match(to_test)
+        a = False if m is None else True
+        return a
+
+    # when should be a datetime object
+    def hint(self, when):
+        return when.isocalendar().week == self.week_number
+
+    def toJSON(self):
+        return {"type": self.type, "week_number": self.week_name}
+
+    def fromJSON(json_data):
+        return WeekNumberHint(json_data["week_number"])
 
 class MonthHint:
     def __init__(self, month_name):
@@ -223,7 +250,7 @@ class RangeHint:
 
 
 def hint_klass_matcher(to_test: str):
-    klasses = [MonthHint, QuarterHint, RangeHint, DayofWeekHint]
+    klasses = [MonthHint, QuarterHint, RangeHint, DayofWeekHint, WeekNumberHint]
     for klass in klasses:
         if klass.test_pattern(to_test):
             return klass

--- a/fs42/schedule_hint.py
+++ b/fs42/schedule_hint.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 
 from fs42 import timings
@@ -167,6 +167,93 @@ class QuarterHint:
     def fromJSON(json_data):
         return QuarterHint(json_data["quarter"])
 
+class CustomHolidayHint:
+    fixed_pattern = re.compile(f"^ *({'|'.join(timings.MONTHS)}) *([0-3]?[0-9])$", re.IGNORECASE)
+    ordinal_pattern = re.compile(f"^(1st|2nd|3rd|4th|last) ({'|'.join(timings.DAYS)}) ({'|'.join(timings.MONTHS)})$", re.IGNORECASE)
+
+    def __init__(self, holiday_name):
+        self.holiday_name = holiday_name
+
+        # grab config from the station_manager
+        if CustomHolidayHint.test_pattern(holiday_name):
+            holiday_conf_str = station_manager.StationManager().get_custom_holidays().get(holiday_name)
+        else:
+            raise ValueError(f"Custom Holiday: {holiday_name} not found in main config")
+        
+        fixed_m = CustomHolidayHint.fixed_pattern.match(holiday_conf_str)
+        ordinal_m = CustomHolidayHint.ordinal_pattern.match(holiday_conf_str)
+
+        self.month = None
+        self.day = None
+        self.weekday_str = None
+        self.n = None
+
+        if fixed_m:
+            self.month = fixed_m.group(1).capitalize()
+            self.day = int(fixed_m.group(2))
+        elif ordinal_m:
+            self.month = ordinal_m.group(3).capitalize()
+            self.weekday_str = ordinal_m.group(2).lower()
+            self.n = -1 if not ordinal_m.group(1)[0].isdigit() else int(ordinal_m.group(1)[0])
+
+        else:
+            raise ValueError(f"Custom Holiday: {holiday_name} date string not valid.")
+
+        self.type = "custom_holiday"
+
+    @staticmethod        
+    def test_pattern(to_test):
+        return to_test in station_manager.StationManager().get_custom_holidays().keys()
+
+    def hint(self, when):
+        year = when.year
+        if self.day:
+            raw_date = datetime.strptime(f"{year} {self.month} {self.day}", "%Y %B %d")
+            calc_date = self._find_weekday(raw_date)
+        elif self.weekday_str:
+            raw_date = datetime.strptime(f"{year} {self.month} 1", "%Y %B %d")
+            calc_date = self._nth_weekday(raw_date, self.weekday_str, self.n)
+        else:
+            # left for expansion
+            # raise error in case we find ourselves here
+            raise ValueError(f"Custom Holiday: {self.holiday_name} configuration read error.")
+
+        return calc_date.day == when.day and calc_date.month == when.month
+    
+    def _find_weekday(self, raw_date):
+        # finds the nearest weekday
+        if raw_date.weekday() == 5:
+            return raw_date - timedelta(days=1)
+        elif raw_date.weekday() == 6:
+            return raw_date + timedelta(days=1)
+        return raw_date
+    
+    def _nth_weekday(self, month, weekday_str, n):
+        # Assumes month is a datetime set to the 1st of the month.
+        # Find the offset from the first
+        weekday = timings.DAYS.index(weekday_str.lower())
+        offset = (weekday - month.weekday()) % 7
+        last_day = self._find_last_day(month)
+        if n >= 0:
+            day = 1 + offset + (n-1) * 7
+            return month.replace(day=day)
+        else:
+            return last_day - timedelta(days=(last_day.weekday() - weekday) % 7)
+
+
+    def _find_last_day(self, when):
+        if when.month == 12:
+            next_first = when.replace(year=when.year+1, month=1, day=1)
+        else:
+            next_first = when.replace(month=when.month+1, day=1)
+        return next_first - timedelta(days=1) 
+
+    def toJSON(self):
+        return {"type": self.type, "custom_holiday": self.holiday_name}
+
+    def fromJSON(json_data):
+        return CustomHolidayHint(json_data["custom_holiday"])
+
 
 class RangeHint:
     # matches patterns like: December 1 - December 25
@@ -250,7 +337,7 @@ class RangeHint:
 
 
 def hint_klass_matcher(to_test: str):
-    klasses = [MonthHint, QuarterHint, RangeHint, DayofWeekHint, WeekNumberHint]
+    klasses = [MonthHint, QuarterHint, RangeHint, DayofWeekHint, WeekNumberHint, CustomHolidayHint]
     for klass in klasses:
         if klass.test_pattern(to_test):
             return klass

--- a/fs42/station_manager.py
+++ b/fs42/station_manager.py
@@ -99,6 +99,9 @@ class StationManager(object):
     def get_day_parts(self):
         return self.server_conf["day_parts"]
 
+    def get_custom_holidays(self):
+        return self.server_conf["custom_holidays"]
+
     def load_main_config(self):
         _l = logging.getLogger("STATIONMANAGER")
         d = self.station_io.load_main_config()
@@ -120,7 +123,8 @@ class StationManager(object):
                     "video_seek_timeout",
                     "overlay_conf",
                     "start_channel",
-                    "follow_static_symlinks"
+                    "follow_static_symlinks",
+                    "custom_holidays",
                 ]
 
                 for key in to_check:

--- a/test/test_schedule_hint.py
+++ b/test/test_schedule_hint.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from fs42.timings import MONTHS
 from fs42.station_manager import StationManager
 from fs42.station_io import StationIO
-from fs42.schedule_hint import MonthHint, QuarterHint, RangeHint, CustomHolidayHint, WeekNumberHint
+from fs42.schedule_hint import WeekNumberHint, MonthHint, QuarterHint, CustomHolidayHint, RangeHint
 import pytest
 
 class TestWeekNumberHint:

--- a/test/test_schedule_hint.py
+++ b/test/test_schedule_hint.py
@@ -3,8 +3,30 @@ from datetime import datetime
 from fs42.timings import MONTHS
 from fs42.station_manager import StationManager
 from fs42.station_io import StationIO
-from fs42.schedule_hint import MonthHint, QuarterHint, RangeHint, CustomHolidayHint
+from fs42.schedule_hint import MonthHint, QuarterHint, RangeHint, CustomHolidayHint, WeekNumberHint
 import pytest
+
+class TestWeekNumberHint:
+    def test_hint_week_1(self):
+        hint = WeekNumberHint('week number 1')
+        assert hint.hint(datetime.fromisoformat('2025-12-29'))
+        assert not hint.hint(datetime.fromisoformat('2027-01-02'))
+
+    def test_hint_week_53(self):
+        hint = WeekNumberHint('week number 53')
+        assert hint.hint(datetime.fromisoformat('2026-12-29'))
+        assert not hint.hint(datetime.fromisoformat('2026-12-27'))
+
+    def test_wrong_hint(self):
+        hint = WeekNumberHint('week number 2')
+        assert not hint.hint(datetime.fromisoformat('2026-03-18'))
+
+    def test_test_pattern(self):
+        assert WeekNumberHint.test_pattern('week number 2')
+        assert WeekNumberHint.test_pattern('Week Number 5')
+        assert not WeekNumberHint.test_pattern('week number 54')
+        assert not WeekNumberHint.test_pattern('aaaaa')
+        assert not WeekNumberHint.test_pattern('week number -10')
 
 class TestMonthHint:
     def test_hint(self):

--- a/test/test_schedule_hint.py
+++ b/test/test_schedule_hint.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
 from datetime import datetime
 from fs42.timings import MONTHS
-from fs42.schedule_hint import MonthHint, QuarterHint, RangeHint
+from fs42.station_manager import StationManager
+from fs42.station_io import StationIO
+from fs42.schedule_hint import MonthHint, QuarterHint, RangeHint, CustomHolidayHint
 import pytest
 
 class TestMonthHint:
@@ -48,6 +51,52 @@ class TestQuarterHint:
         assert not QuarterHint.test_pattern("s2q3")
         assert QuarterHint.test_pattern("q1")
         assert QuarterHint.test_pattern("q3")
+
+class TestCustomHolidayHint:
+    def setup_method(self):
+        # reset the Borg singleton so each test starts clean
+        StationManager._StationManager__we_are_all_one = {}
+        StationManager._initialized = False
+        StationManager.stations = []
+
+    def _make_manager(self, custom_holidays):
+        config_data = {"server_port": 4242, "custom_holidays": custom_holidays}
+        with patch.object(StationIO, 'load_main_config', return_value=config_data):
+            with patch('fs42.station_io.glob.glob', return_value=[]):
+                return StationManager()
+
+    def test_nearest_weekday(self):
+        self._make_manager({"christmas": "December 25"})
+        hint = CustomHolidayHint("christmas")
+        # Dec 25, 2027 is a Saturday -> observed Friday Dec 24
+        assert hint.hint(datetime.fromisoformat('2027-12-24'))
+        assert not hint.hint(datetime.fromisoformat('2027-12-25'))
+        # Dec 25, 2025 is a Thursday Should show up on the day.
+        assert hint.hint(datetime.fromisoformat('2025-12-25'))
+
+    def test_ordinal_holiday(self):
+        self._make_manager({"thanksgiving": "4th thursday november"})
+        hint = CustomHolidayHint("thanksgiving")
+        assert hint.hint(datetime.fromisoformat('2026-11-26'))
+        assert not hint.hint(datetime.fromisoformat('2026-11-25'))
+
+    def test_ordinal_uppercase(self):
+        self._make_manager({"thanksgiving": "4th Thursday November"})
+        hint = CustomHolidayHint("thanksgiving")
+        assert hint.hint(datetime.fromisoformat('2026-11-26'))
+        assert not hint.hint(datetime.fromisoformat('2026-11-25'))
+
+    def test_last_weekday(self):
+        self._make_manager({"memorial_day": "last monday may"})
+        hint = CustomHolidayHint("memorial_day")
+        assert hint.hint(datetime.fromisoformat('2026-05-25'))
+        assert not hint.hint(datetime.fromisoformat('2026-05-26'))
+
+    def test_test_pattern(self):
+        self._make_manager({"memorial_day": "last monday may"})
+        assert not CustomHolidayHint.test_pattern('around memorial day')
+        assert not CustomHolidayHint.test_pattern('MeMoRiAl_DaY')
+        assert CustomHolidayHint.test_pattern('memorial_day')
 
 class TestRangeHint:
     def test_range(self):


### PR DESCRIPTION
WeekNumberHint adds support for a week number matched from `"week number <1-52>"` 

CustomHolidayHint adds support for user defined holiday definitions. The definitions are in the global config, and expects a dict of holiday names, that map to strings.  Currently accepts strings that match the following:
observed days = `'<month> <day>'` eg: `'November 11'`This will return true on the nearest weekday to the date.  Eg if the date falls on a Saturday hint is valid on the preceding Friday.

ordinal days = `'<1st|2nd|3rd|4th|last> <weekday> <month>'` eg: `"4th thursday november"`.

As per discord conversation: I don't think this is complete, and I'm not sure how to tie it in properly. 

Thanks,