### PR TITLE
Add optional station-level parental controls

### DIFF
--- a/field_player.py
+++ b/field_player.py
@@ -78,6 +78,11 @@ def input_check():
                 case "mpv_command":
                     action = q_message.get("action", "")
                     return PlayerOutcome(PlayerState.SUCCESS, f"mpv_command:{action}")
+                case "parental_digit":
+                    digit = str(q_message.get("digit", ""))
+                    return PlayerOutcome(PlayerState.SUCCESS, f"parental_digit:{digit}")
+                case "parental_clear":
+                    return PlayerOutcome(PlayerState.SUCCESS, "parental_clear")
 
 
     channel_socket = StationManager().server_conf["channel_socket"]
@@ -215,6 +220,7 @@ def main_loop(transition_fn, shutdown_queue=None, api_proc=None, schedule_lock=N
 
         if player_state.status == PlayerState.CHANNEL_CHANGE:
             stuck_timer = 0
+            player.parental_unlocked_network = None
             # Cache stations to prevent race conditions during reload
             station_cache = manager.stations
             stations_len = len(station_cache)
@@ -283,6 +289,12 @@ def main_loop(transition_fn, shutdown_queue=None, api_proc=None, schedule_lock=N
 
             # long_change_effect(player, reception)
             transition_fn(player, reception)
+
+        elif player_state.status == PlayerState.PARENTAL_CONTROLS:
+            stuck_timer = 0
+            player_state = player.prompt_parental_controls(channel_conf)
+            if player_state.status != PlayerState.SUCCESS:
+                skip_play = True
 
         elif player_state.status == PlayerState.PLAY_FILE:
             print("Got playfile!", player_state.payload )

--- a/fs42/fs42_server/api/player.py
+++ b/fs42/fs42_server/api/player.py
@@ -259,6 +259,29 @@ async def mpv_cycle_audio(request: Request):
     return await _queue_mpv_command(request, "cycle_audio")
 
 
+@router.post("/parental/digit/{digit}")
+async def parental_digit(request: Request, digit: str):
+    if not digit.isdigit() or len(digit) != 1:
+        raise HTTPException(status_code=400, detail="Digit must be a single number.")
+
+    command_queue = request.app.state.player_command_queue
+    if not command_queue:
+        raise HTTPException(status_code=503, detail="Player command queue is not connected.")
+
+    command_queue.put({"command": "parental_digit", "digit": digit})
+    return {"handled": True}
+
+
+@router.post("/parental/clear")
+async def parental_clear(request: Request):
+    command_queue = request.app.state.player_command_queue
+    if not command_queue:
+        raise HTTPException(status_code=503, detail="Player command queue is not connected.")
+
+    command_queue.put({"command": "parental_clear"})
+    return {"handled": True}
+
+
 @router.post("/ticker")
 async def show_ticker(request: Request):
     data = await request.json()

--- a/fs42/overlay/parental_controls.py
+++ b/fs42/overlay/parental_controls.py
@@ -14,9 +14,9 @@ THEMES = {
         "box": QColor(12, 20, 38, 235),
         "border": QColor(230, 230, 230),
         "pin_box": QColor(0, 0, 0, 170),
-        "text": QColor(255, 255, 255),
-        "muted": QColor(190, 190, 190),
-        "message": QColor(220, 220, 220),
+        "text": QColor(255, 230, 80),
+        "muted": QColor(220, 205, 120),
+        "message": QColor(255, 230, 80),
         "error": QColor(255, 210, 210),
     },
     "modern": {

--- a/fs42/overlay/parental_controls.py
+++ b/fs42/overlay/parental_controls.py
@@ -1,0 +1,214 @@
+import sys
+import signal
+import multiprocessing
+from queue import Empty
+
+from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtGui import QColor, QPainter, QFont, QPen
+from PySide6.QtCore import Qt, QRect, QTimer
+
+
+THEMES = {
+    "classic": {
+        "screen": QColor(0, 0, 0, 0),
+        "box": QColor(12, 20, 38, 235),
+        "border": QColor(230, 230, 230),
+        "pin_box": QColor(0, 0, 0, 170),
+        "text": QColor(255, 255, 255),
+        "muted": QColor(190, 190, 190),
+        "message": QColor(220, 220, 220),
+        "error": QColor(255, 210, 210),
+    },
+    "modern": {
+        "screen": QColor(0, 0, 0, 0),
+        "box": QColor(28, 28, 34, 235),
+        "border": QColor(90, 170, 255),
+        "pin_box": QColor(14, 14, 18, 210),
+        "text": QColor(255, 255, 255),
+        "muted": QColor(205, 205, 205),
+        "message": QColor(225, 225, 225),
+        "error": QColor(255, 120, 120),
+    },
+    "minimal": {
+        "screen": QColor(0, 0, 0, 0),
+        "box": QColor(245, 245, 245, 235),
+        "border": QColor(40, 40, 40),
+        "pin_box": QColor(255, 255, 255, 220),
+        "text": QColor(20, 20, 20),
+        "muted": QColor(80, 80, 80),
+        "message": QColor(50, 50, 50),
+        "error": QColor(160, 0, 0),
+    },
+}
+
+
+class ParentalControlsWindow(QWidget):
+    def __init__(self, network_name, queue, theme_name="classic", parent=None):
+        super().__init__(parent)
+        self.network_name = network_name
+        self.queue = queue
+        self.theme = THEMES.get(theme_name, THEMES["classic"])
+        self.digits = 0
+        self.error = False
+
+        self.setWindowFlags(
+            Qt.FramelessWindowHint
+            | Qt.WindowStaysOnTopHint
+            | Qt.Tool
+            | Qt.WindowDoesNotAcceptFocus
+            | Qt.X11BypassWindowManagerHint
+        )
+        self.setAttribute(Qt.WA_ShowWithoutActivating)
+        self.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self.setFocusPolicy(Qt.NoFocus)
+        self.setCursor(Qt.BlankCursor)
+
+        screen = QApplication.primaryScreen()
+        if screen:
+            screen_rect = screen.geometry()
+            self.scale_factor = screen_rect.height() / 1080.0
+        else:
+            screen_rect = QRect(0, 0, 1920, 1080)
+            self.scale_factor = 1.0
+
+        self.box_width = self.scaled(560)
+        self.box_height = self.scaled(280)
+        box_x = screen_rect.x() + (screen_rect.width() - self.box_width) // 2
+        box_y = screen_rect.y() + (screen_rect.height() - self.box_height) // 2
+        self.setGeometry(box_x, box_y, self.box_width, self.box_height)
+
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.poll_queue)
+        self.timer.start(50)
+
+    def poll_queue(self):
+        try:
+            while True:
+                message = self.queue.get_nowait()
+                if message.get("close"):
+                    QApplication.quit()
+                    return
+
+                self.digits = int(message.get("digits", self.digits))
+                self.error = bool(message.get("error", False))
+                self.update()
+        except Empty:
+            pass
+
+    def scaled(self, value):
+        return int(value * self.scale_factor)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        theme = self.theme
+        box_rect = QRect(0, 0, self.width() - 1, self.height() - 1)
+
+        painter.setPen(QPen(theme["border"], self.scaled(3)))
+        painter.setBrush(theme["box"])
+        painter.drawRoundedRect(box_rect, self.scaled(14), self.scaled(14))
+
+        title_font = QFont("Arial", self.scaled(28), QFont.Bold)
+        body_font = QFont("Arial", self.scaled(18))
+        pin_font = QFont("Arial", self.scaled(30), QFont.Bold)
+
+        painter.setPen(theme["text"])
+        painter.setFont(title_font)
+        painter.drawText(
+            QRect(0, self.scaled(28), self.width(), self.scaled(42)),
+            Qt.AlignCenter,
+            "PARENTAL CONTROLS",
+        )
+
+        painter.setFont(body_font)
+        painter.drawText(
+            QRect(
+                self.scaled(40),
+                self.scaled(88),
+                self.width() - self.scaled(80),
+                self.scaled(36),
+            ),
+            Qt.AlignCenter,
+            f"{self.network_name} requires a PIN.",
+        )
+
+        message = "Incorrect PIN. Try again." if self.error else "Enter PIN to continue."
+        painter.setPen(theme["error"] if self.error else theme["message"])
+        painter.drawText(
+            QRect(
+                self.scaled(40),
+                self.scaled(122),
+                self.width() - self.scaled(80),
+                self.scaled(34),
+            ),
+            Qt.AlignCenter,
+            message,
+        )
+
+        pin_box_size = self.scaled(48)
+        pin_gap = self.scaled(18)
+        total_pin_width = (pin_box_size * 4) + (pin_gap * 3)
+        start_x = (self.width() - total_pin_width) // 2
+        pin_y = self.scaled(168)
+
+        painter.setFont(pin_font)
+        for index in range(4):
+            rect = QRect(
+                start_x + index * (pin_box_size + pin_gap),
+                pin_y,
+                pin_box_size,
+                pin_box_size,
+            )
+            painter.setPen(QPen(theme["border"], self.scaled(2)))
+            painter.setBrush(theme["pin_box"])
+            painter.drawRoundedRect(rect, self.scaled(6), self.scaled(6))
+
+            if index < self.digits:
+                painter.setPen(theme["text"])
+                painter.drawText(rect, Qt.AlignCenter, "*")
+
+        painter.setFont(QFont("Arial", self.scaled(14)))
+        painter.setPen(theme["muted"])
+        painter.drawText(
+            QRect(
+                self.scaled(40),
+                self.scaled(232),
+                self.width() - self.scaled(80),
+                self.scaled(28),
+            ),
+            Qt.AlignCenter,
+            "Use channel up/down to leave this station.",
+        )
+
+        painter.end()
+
+
+def signal_handler(sig, frame):
+    QApplication.quit()
+
+
+def run_parental_controls_app(network_name, queue, theme_name="classic"):
+    signal.signal(signal.SIGINT, signal_handler)
+
+    app = QApplication(sys.argv)
+    window = ParentalControlsWindow(network_name, queue, theme_name)
+    window.show()
+    window.raise_()
+
+    sys.exit(app.exec())
+
+
+def run_parental_controls(network_name, queue, theme_name="classic"):
+    def parental_controls_process():
+        run_parental_controls_app(network_name, queue, theme_name)
+
+    process = multiprocessing.Process(target=parental_controls_process)
+    process.start()
+    return process
+
+
+if __name__ == "__main__":
+    queue = multiprocessing.Queue()
+    queue.put({"digits": 0, "error": False})
+    run_parental_controls_app("LOCKED STATION", queue)

--- a/fs42/pi/remote_controller.py
+++ b/fs42/pi/remote_controller.py
@@ -147,10 +147,39 @@ def send_channel_change():
             clear_press_socket()
 
 
+def send_parental_digit_if_active(number):
+    try:
+        status_response = requests.get(f'{FS42_BASE_URL}/player/status', timeout=2)
+        if not status_response.ok:
+            return False
+
+        status = status_response.json()
+        if not status.get("awaiting_pin"):
+            return False
+
+        response = requests.post(
+            f'{FS42_BASE_URL}/player/parental/digit/{number}',
+            timeout=2
+        )
+
+        if response.ok:
+            print(f"Parental controls PIN digit entered: {number}")
+            return True
+
+        print(f"Parental controls digit failed: {response.status_code}")
+        return False
+    except Exception as e:
+        print(f"Parental controls digit error: {e}")
+        return False
+
+
 def number_pressed(number):
     """Handle number key presses from remote"""
     global channel_input, channel_input_timer
-    
+
+    if send_parental_digit_if_active(number):
+        return
+
     with input_lock:
         # Cancel any existing timer
         if channel_input_timer:

--- a/fs42/station_config_schema.json
+++ b/fs42/station_config_schema.json
@@ -493,6 +493,10 @@
             }
           }
         },
+        "parental_controls": {
+          "type": "boolean",
+          "description": "Require the global parental controls PIN before playing this station"
+        },
         "streams": {
           "type": "array",
           "description": "Stream configurations for streaming networks",

--- a/fs42/station_manager.py
+++ b/fs42/station_manager.py
@@ -132,7 +132,9 @@ class StationManager(object):
                     "video_seek_timeout",
                     "overlay_conf",
                     "start_channel",
-                    "follow_static_symlinks"
+                    "follow_static_symlinks",
+                    "parental_controls_pin",
+                    "parental_controls_theme"
                 ]
 
                 for key in to_check:

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -44,13 +44,24 @@ logging.basicConfig(format="%(asctime)s %(levelname)s:%(name)s:%(message)s", lev
 
 
 def update_status_socket(
-    status, network_name, channel, title=None, timestamp="%Y-%m-%dT%H:%M:%S", duration=None, file_path=None, content_type=None
+    status,
+    network_name,
+    channel,
+    title=None,
+    timestamp="%Y-%m-%dT%H:%M:%S",
+    duration=None,
+    file_path=None,
+    content_type=None,
+    awaiting_pin=False,
+    pin_digits_entered=0,
 ):
     status_obj = {
         "status": status,
         "network_name": network_name,
         "channel_number": channel,
         "timestamp": datetime.datetime.now().strftime(timestamp),
+        "awaiting_pin": awaiting_pin,
+        "pin_digits_entered": pin_digits_entered,
     }
     if title is not None:
         status_obj["title"] = title
@@ -73,6 +84,7 @@ class PlayerState(Enum):
     CHANNEL_CHANGE = 4
     EXIT_COMMAND = 5
     PLAY_FILE = 6
+    PARENTAL_CONTROLS = 7
 
 
 class PlayerOutcome:
@@ -192,6 +204,9 @@ class StationPlayer:
         self.skip_reception_check = False
         self.web_process = None
         self.web_queue = None
+        self.parental_controls_process = None
+        self.parental_controls_queue = None
+        self.parental_unlocked_network = None
         self.scrambler = None
         self.now_playing_process = None
         self.schedule_lock = None
@@ -235,6 +250,173 @@ class StationPlayer:
             return True
 
         return False
+
+    def _start_parental_controls_overlay(self, network_name):
+        self._close_parental_controls_overlay()
+
+        try:
+            from fs42.overlay.parental_controls import run_parental_controls
+
+            self.parental_controls_queue = multiprocessing.Queue()
+            self.parental_controls_process = run_parental_controls(
+                network_name,
+                self.parental_controls_queue,
+                self._parental_controls_theme(),
+            )
+            self._update_parental_controls_overlay()
+        except Exception as e:
+            self._l.warning(f"Could not start parental controls overlay: {e}")
+            self.parental_controls_process = None
+            self.parental_controls_queue = None
+
+    def _update_parental_controls_overlay(self, digits=0, error=False):
+        if self.parental_controls_queue:
+            self.parental_controls_queue.put({
+                "digits": digits,
+                "error": error
+            })
+
+    def _close_parental_controls_overlay(self):
+        if self.parental_controls_queue:
+            try:
+                self.parental_controls_queue.put({"close": True})
+            except Exception:
+                pass
+
+        if self.parental_controls_process and self.parental_controls_process.is_alive():
+            try:
+                self.parental_controls_process.join(timeout=0.2)
+                if self.parental_controls_process.is_alive():
+                    self.parental_controls_process.terminate()
+                    self.parental_controls_process.join(timeout=0.2)
+                if self.parental_controls_process.is_alive():
+                    self.parental_controls_process.kill()
+                    self.parental_controls_process.join(timeout=0.1)
+            except Exception as e:
+                self._l.warning(f"Error terminating parental controls overlay: {e}")
+
+        self.parental_controls_process = None
+        self.parental_controls_queue = None
+
+    def _parental_controls_pin(self):
+        pin = str(StationManager().server_conf.get("parental_controls_pin", ""))
+        if len(pin) == 4 and pin.isdigit():
+            return pin
+
+        if pin:
+            self._l.warning("parental_controls_pin must be exactly 4 digits")
+        return None
+
+    def _parental_controls_theme(self):
+        theme = StationManager().server_conf.get("parental_controls_theme", "classic")
+        if theme in ("classic", "modern", "minimal"):
+            return theme
+
+        self._l.warning(f"Unknown parental_controls_theme: {theme}")
+        return "classic"
+
+    def _parental_controls_required(self, network_name):
+        if not self._parental_controls_pin():
+            return False
+
+        station_config = StationManager().station_by_name(network_name)
+        if not station_config:
+            return False
+
+        station_conf = station_config.get("station_conf", {})
+        return bool(
+            station_config.get("parental_controls")
+            or station_conf.get("parental_controls")
+        )
+
+    def prompt_parental_controls(self, station_config):
+        network_name = station_config["network_name"]
+        channel_number = station_config["channel_number"]
+        pin = self._parental_controls_pin()
+
+        if not pin:
+            return PlayerOutcome(PlayerState.SUCCESS)
+
+        entered = ""
+        self.stop_player()
+        self._start_parental_controls_overlay(network_name)
+        update_status_socket(
+            "playing",
+            network_name,
+            channel_number,
+            title="Parental Controls",
+            awaiting_pin=True,
+            pin_digits_entered=0,
+        )
+
+        try:
+            while True:
+                response = self.input_check_fn()
+                if not response:
+                    time.sleep(0.05)
+                    continue
+
+                if self.handle_runtime_command_outcome(response):
+                    continue
+
+                if response.status != PlayerState.SUCCESS:
+                    return response
+
+                if not isinstance(response.payload, str):
+                    continue
+
+                if response.payload.startswith("parental_digit:"):
+                    digit = response.payload.split(":", 1)[1]
+                    if not digit.isdigit() or len(digit) != 1:
+                        continue
+
+                    entered += digit
+                    self._update_parental_controls_overlay(len(entered), False)
+                    update_status_socket(
+                        "playing",
+                        network_name,
+                        channel_number,
+                        title="Parental Controls",
+                        awaiting_pin=True,
+                        pin_digits_entered=len(entered),
+                    )
+
+                    if len(entered) >= len(pin):
+                        if entered == pin:
+                            self.parental_unlocked_network = network_name
+                            return PlayerOutcome(PlayerState.SUCCESS)
+
+                        entered = ""
+                        self._update_parental_controls_overlay(0, True)
+                        update_status_socket(
+                            "playing",
+                            network_name,
+                            channel_number,
+                            title="Parental Controls",
+                            awaiting_pin=True,
+                            pin_digits_entered=0,
+                        )
+
+                elif response.payload == "parental_clear":
+                    entered = ""
+                    self._update_parental_controls_overlay(0, False)
+                    update_status_socket(
+                        "playing",
+                        network_name,
+                        channel_number,
+                        title="Parental Controls",
+                        awaiting_pin=True,
+                        pin_digits_entered=0,
+                    )
+        finally:
+            self._close_parental_controls_overlay()
+            update_status_socket(
+                "idle",
+                network_name,
+                channel_number,
+                awaiting_pin=False,
+                pin_digits_entered=0,
+            )
 
     def _close_now_playing(self):
         # terminate the Now Playing overlay if it's running
@@ -317,6 +499,8 @@ class StationPlayer:
 
         self.web_process = None
         self.web_queue = None
+
+        self._close_parental_controls_overlay()
 
         # Terminate any running now playing overlay
         self._l.info("Terminating now playing overlay")
@@ -815,6 +999,10 @@ class StationPlayer:
 
     def play_slot(self, network_name, when):
         liquid = LiquidManager()
+
+        if self._parental_controls_required(network_name):
+            if self.parental_unlocked_network != network_name:
+                return PlayerOutcome(PlayerState.PARENTAL_CONTROLS, network_name)
 
         try:
             play_point = liquid.get_play_point(network_name, when)

--- a/fs42/station_player.py
+++ b/fs42/station_player.py
@@ -308,12 +308,12 @@ class StationPlayer:
         return None
 
     def _parental_controls_theme(self):
-        theme = StationManager().server_conf.get("parental_controls_theme", "classic")
+        theme = StationManager().server_conf.get("parental_controls_theme", "minimal")
         if theme in ("classic", "modern", "minimal"):
             return theme
 
         self._l.warning(f"Unknown parental_controls_theme: {theme}")
-        return "classic"
+        return "minimal"
 
     def _parental_controls_required(self, network_name):
         if not self._parental_controls_pin():


### PR DESCRIPTION
## Overview

This PR adds optional station-level parental controls.

A global 4-digit PIN can be configured in `main_config.json`, and individual stations can opt into requiring that PIN before playback begins. When a protected station is selected, FS42 displays a PIN prompt before playing that station.

## Configuration

Add a global 4-digit PIN in `confs/main_config.json`:

```json
"parental_controls_pin": "1234"
```

Then enable parental controls on any station by adding this to that station's `station_conf`:

```json
"parental_controls": true
```

If `parental_controls` is omitted or set to `false`, the station behaves normally.

An optional prompt theme can also be configured in `main_config.json`:

```json
"parental_controls_theme": "classic"
```

Built-in theme options are:

```
classic  - dark 90s-style prompt with yellow text
modern   - dark prompt with blue accent
minimal  - light, plain prompt and the default fallback
```

If `parental_controls_theme` is omitted or invalid, FS42 falls back to `minimal`.

<img width="306" height="231" alt="classic" src="https://github.com/user-attachments/assets/051b544d-eda8-4857-9eb3-a085db6f7734" />

**Classic**

<img width="306" height="231" alt="modern" src="https://github.com/user-attachments/assets/9acbf6f1-12fa-49ca-85fa-59adcca9bad6" />

**Modern**

<img width="306" height="231" alt="minimal" src="https://github.com/user-attachments/assets/d6acdaf5-4888-4453-90f8-563300a63127" />

**Minimal**

## Behavior

When a protected station is selected:

- FS42 stops current playback and displays a PIN prompt.
- Number input from the physical/keyboard remote is captured as PIN entry instead of channel entry.
- A correct PIN unlocks the station and begins normal playback.
- An incorrect PIN clears the entry and allows another attempt.
- Channel up/down can still be used to leave the protected station without entering the PIN.
- Leaving and returning to the protected station requires the PIN again.
- Unprotected stations continue to play normally.

## Current limitations / caveats

- PIN entry is currently supported through the physical/keyboard remote path and through the direct API digit endpoint.
- PIN entry is not currently supported through the web remote number buttons. The web remote treats number input as channel-entry input, so its numeric keypad does not automatically become PIN input while a protected station is awaiting a PIN.
- The PIN is global, not per-station.
- The PIN must be exactly four numeric digits.
- The unlock is intentionally temporary. Leaving the protected station and returning to it requires the PIN again.
- The prompt is a Qt overlay window, so behavior may vary slightly by platform/window manager, especially around fullscreen/mpv stacking behavior.

## Implementation notes

The PIN prompt uses a small PySide6/Qt overlay process under `fs42/overlay/`, following the same general overlay pattern as existing FS42 overlays.

The player exposes PIN-waiting state through the existing `/player/status` payload using:

```json
"awaiting_pin": true
```

PIN digit input is sent through the existing API command queue path.

## Files changed

- `field_player.py`
- `fs42/station_player.py`
- `fs42/station_manager.py`
- `fs42/station_config_schema.json`
- `fs42/fs42_server/api/player.py`
- `fs42/pi/remote_controller.py`
- `fs42/overlay/parental_controls.py`

## Testing

Tested locally with a protected station.
Confirmed:

- Protected station displays the PIN prompt before playback.
- Current playback stops while the PIN prompt is active.
- Correct PIN unlocks playback.
- Incorrect PIN clears the entry and accepts a new attempt.
- PIN entry works through API digit input.
- Remote number input is routed to PIN entry while the player is awaiting a PIN.
- Channel up/down can leave the protected station without unlocking it.
- Returning to the protected station requires the PIN again.
- Unprotected stations continue to play normally.
- `/player/status` reports `awaiting_pin: true` while the PIN prompt is active.
- Web remote doesn't treat the PIN state as an error, but web remote numeric PIN entry is not implemented in this PR.
