### PR TITLE
Hide web/streaming channels that aren't reachable; Add status in web UI

### DIFF
--- a/confs/examples/diagnostic.json
+++ b/confs/examples/diagnostic.json
@@ -1,0 +1,9 @@
+{"station_conf" : {
+    "network_name" : "Diagnostics",
+    "network_long_name": "System Diagnostics",
+    "network_type" : "web",
+    "channel_number": 99,
+    "web_url": "http://localhost:4242/static/diagnostics.html",
+    "refresh_interval": 0,
+    "always_available": true
+}}

--- a/docs/MAIN_CONFIG_README.md
+++ b/docs/MAIN_CONFIG_README.md
@@ -45,6 +45,9 @@ The `confs/main_config.json` file is optional. If it doesn't exist, FieldStation
 | `normalize_titles` | boolean | `false` | Enable automatic title normalization from filenames |
 | `title_patterns` | array | `[]` | Custom regex patterns for title parsing (see below) |
 | `follow_static_symlinks` | boolean | `false` | Serve symlinks that point outside the static directories (see below) |
+| `reachability_check` | boolean | `true` | Probe `web`/`streaming` stations' URLs and treat unreachable ones as offline (skipped by channel up/down, dropped from the native guide, badged OFFLINE in the web UI). Set `false` to disable entirely. |
+| `reachability_interval` | integer | `30` | Seconds between reachability probe cycles |
+| `reachability_timeout` | number | `5` | Per-connection TCP timeout in seconds for each probe |
 
 ## Day Parts
 

--- a/docs/STATION_CONFIG_README.md
+++ b/docs/STATION_CONFIG_README.md
@@ -75,6 +75,7 @@ The `network_type` property determines how the station operates:
 | `channel_number` | integer | **Required.** Channel number | Any positive integer |
 | `network_type` | string | Type of network operation | `"standard"`, `"web"`, `"guide"`, `"loop"`, `"streaming"` |
 | `hidden` | boolean | Hide channel from guide listings | `true`, `false` |
+| `always_available` | boolean | Web/streaming only. Never treat this channel as offline (see [Offline Channels](#offline-channels)) | `true`, `false` |
 | `active_rules` | object | Availability rules for when this config should be active | See [Active Rules](#active-rules) below |
 
 ### Scheduling Properties (Standard Networks)
@@ -221,6 +222,7 @@ If no `fallback_tag` is specified and content is not found, the scheduler will g
 |----------|------|-------------|
 | `web_url` | string | URL to display (e.g., `"http://localhost:4242/diagnostics.html"`) |
 | `refresh_interval` | number | Seconds between automatic page reloads. Omit or set to `0` to disable. |
+| `always_available` | boolean | If `true`, the channel is never treated as offline even when `web_url` is unreachable. Use this for locally hosted pages such as the diagnostics channel. Defaults to `false`. |
 
 ### Guide Network Properties
 
@@ -279,6 +281,39 @@ Each stream object contains:
   "url": "https://example.com/stream.m3u8",
   "duration": 30,
   "title": "Stream Title"
+}
+```
+
+Streaming networks also accept `always_available` (boolean) - see [Offline Channels](#offline-channels).
+
+### Offline Channels
+
+`web` and `streaming` networks depend on remote hosts. FieldStation42 periodically TCP-connects to the
+host/port of each `web_url` and `streams[*].url`. When **none** of a station's URLs are reachable the
+station is treated as **offline**:
+
+- it is skipped by channel up/down (a direct tune to its channel number still works),
+- it is removed from the native (`guide` network type) TV guide,
+- it stays listed on the port-4242 web UI (Home table, web guide, Channels page) with an **OFFLINE** badge.
+
+Reachability is unknown until the first probe cycle finishes after start-up (a few seconds), and
+unknown counts as reachable, so a guide channel that is the start channel may list an offline
+station on its first render; the guide rebuilds about once a minute and drops it then.
+
+Web/streaming stations with no URLs configured are treated as reachable. Set `"always_available": true`
+on a station to opt out of the check entirely (recommended for the locally hosted diagnostics channel).
+The probe interval/timeout and a global on/off switch live in `main_config.json` - see
+`reachability_check`, `reachability_interval` and `reachability_timeout` in `MAIN_CONFIG_README.md`.
+
+```json
+{
+  "station_conf": {
+    "network_name": "Diagnostics",
+    "network_type": "web",
+    "channel_number": 99,
+    "web_url": "http://localhost:4242/static/diagnostics.html",
+    "always_available": true
+  }
 }
 ```
 

--- a/field_player.py
+++ b/field_player.py
@@ -97,11 +97,53 @@ def input_check():
 
 
 
+def skip_offline_start_channel(manager, channel_index, logger):
+    """If the initial channel is a web/streaming station, wait (bounded) for the first
+    reachability check and advance to the next visible station when it is offline.
+    Explicit ``hidden`` stations are left alone here - that is existing behaviour."""
+    stations = manager.stations
+    if not stations:
+        return channel_index
+    station = stations[channel_index]
+    if station.get("network_type") not in ("web", "streaming"):
+        return channel_index
+    if station.get("always_available", False):
+        return channel_index
+    if not manager.server_conf.get("reachability_check", True):
+        return channel_index
+
+    from fs42.reachability import get_monitor
+
+    monitor = get_monitor()
+    timeout = float(manager.server_conf.get("reachability_timeout", 5)) + 2.0
+    if not monitor.wait_first_check(timeout=timeout):
+        logger.warning("Reachability check did not finish in %.1fs - starting on saved channel", timeout)
+        return channel_index
+    if not manager.is_channel_offline(station):
+        return channel_index
+
+    logger.warning(f"Start channel '{station['network_name']}' is offline - advancing to next visible channel")
+    idx = channel_index
+    for _ in range(len(stations)):
+        idx = idx + 1 if idx + 1 < len(stations) else 0
+        if not manager.is_hidden(stations[idx]):
+            return idx
+    logger.warning("No visible station found - starting on saved channel anyway")
+    return channel_index
+
+
 def main_loop(transition_fn, shutdown_queue=None, api_proc=None, schedule_lock=None):
     manager = StationManager()
     reception = ReceptionStatus()
     logger = logging.getLogger("MainLoop")
     logger.info("Starting main loop")
+
+    if manager.server_conf.get("reachability_check", True) and any(
+        s.get("network_type") in ("web", "streaming") for s in manager.stations
+    ):
+        from fs42.reachability import get_monitor
+        get_monitor()
+        logger.info("Reachability monitor started for web/streaming channels")
 
     # set up the live schedule agent if configured
     schedule_agent = None
@@ -148,6 +190,8 @@ def main_loop(transition_fn, shutdown_queue=None, api_proc=None, schedule_lock=N
     if channel_index >= len(manager.stations):
         logger.warning("Saved channel index %d is out of range, resetting to 0", channel_index)
         channel_index = 0
+
+    channel_index = skip_offline_start_channel(manager, channel_index, logger)
 
     player = StationPlayer(manager.stations[channel_index], input_check)
     if schedule_lock:
@@ -258,13 +302,18 @@ def main_loop(transition_fn, shutdown_queue=None, api_proc=None, schedule_lock=N
                             tune_up = False
                             logger.debug("Got channel down command")
                             found = False
-                            while not found:
+                            start_index = channel_index
+                            for _ in range(stations_len):
                                 channel_index -= 1
-                                
+
                                 if channel_index < 0:
                                     channel_index = stations_len-1
-                                if not station_cache[channel_index]["hidden"]:
+                                if not manager.is_hidden(station_cache[channel_index]):
                                     found = True
+                                    break
+                            if not found:
+                                logger.warning("No visible station to tune down to - staying on current channel")
+                                channel_index = start_index
 
 
                 except Exception as e:
@@ -276,10 +325,16 @@ def main_loop(transition_fn, shutdown_queue=None, api_proc=None, schedule_lock=N
             if tune_up:
                 logger.info("Starting channel change")
                 found = False
-                while not found:
+                start_index = channel_index
+                for _ in range(stations_len):
                     channel_index += 1
                     channel_index = channel_index if channel_index < stations_len else 0
-                    found = not station_cache[channel_index]["hidden"]
+                    if not manager.is_hidden(station_cache[channel_index]):
+                        found = True
+                        break
+                if not found:
+                    logger.warning("No visible station to tune up to - staying on current channel")
+                    channel_index = start_index
 
             # save the player state
             with shelve.open(STATE_SHELVE) as s:

--- a/fs42/fs42_server/api/media.py
+++ b/fs42/fs42_server/api/media.py
@@ -9,6 +9,7 @@ logger = logging.getLogger("media_api")
 
 AUDIO_EXTENSIONS = {'.mp3', '.ogg', '.wav', '.flac', '.aac', '.m4a', '.opus'}
 VIDEO_EXTENSIONS = {'.mp4', '.mov', '.webm', '.avi', '.mkv', '.m4v'}
+IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.bmp', '.svg', '.webp'}
 
 # project root: fs42/fs42_server/api/media.py -> up three levels
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
@@ -65,6 +66,24 @@ async def serve_file(path: str):
 
     ext = os.path.splitext(resolved)[1].lower()
     if ext not in AUDIO_EXTENSIONS and ext not in VIDEO_EXTENSIONS:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="unsupported file type")
+
+    media_type, _ = mimetypes.guess_type(resolved)
+    return FileResponse(resolved, media_type=media_type or "application/octet-stream")
+
+
+@router.get("/image")
+async def serve_image(path: str):
+    """Serve an image from inside the project root (e.g. a station logo: logos/StationLogo.png)."""
+    resolved = safe_resolve(path)
+
+    if not os.path.exists(resolved):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="file not found")
+    if not os.path.isfile(resolved):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="path is not a file")
+
+    ext = os.path.splitext(resolved)[1].lower()
+    if ext not in IMAGE_EXTENSIONS:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="unsupported file type")
 
     media_type, _ = mimetypes.guess_type(resolved)

--- a/fs42/fs42_server/api/summary.py
+++ b/fs42/fs42_server/api/summary.py
@@ -19,6 +19,8 @@ async def get_summary():
             "channel_number": station["channel_number"],
             "_has_schedule": station["_has_schedule"],
             "hidden": station.get("hidden", False),
+            "channel_offline": StationManager().is_channel_offline(station),
+            "network_type": station.get("network_type", "standard"),
             "catalog_summary": CatalogAPI.get_summary(station),
             "schedule_summary": sched_summary,
         }
@@ -34,6 +36,8 @@ def get_channels():
             "network_long_name": station.get("network_long_name", ""),
             "channel_number": station["channel_number"],
             "hidden": station.get("hidden", False),
+            "channel_offline": StationManager().is_channel_offline(station),
+            "network_type": station.get("network_type", "standard"),
             "has_schedule": station.get("_has_schedule", False),
         }
         for station in StationManager().stations

--- a/fs42/fs42_server/static/common.js
+++ b/fs42/fs42_server/static/common.js
@@ -133,6 +133,13 @@ async function fetchCatalog(networkId) {
 }
 
 // Render summary table (used in index.html)
+function offlineBadge(station) {
+    if (!station || !station.channel_offline) return '';
+    return '<span class="fs42-offline-badge" title="Remote URL(s) unreachable - hidden from channel up/down and the native guide" ' +
+        'style="display:inline-block;margin-left:0.5em;padding:0.05em 0.45em;border-radius:3px;font-size:0.7em;font-weight:700;' +
+        'letter-spacing:0.05em;background:#da3633;color:#fff;vertical-align:middle;">OFFLINE</span>';
+}
+
 function renderSummaryTable(stations) {
     if (!stations.length) return '<p>No stations found.</p>';
     let html = '<table class="pure-table pure-table-horizontal" style="width:100%;margin-top:1em;">';
@@ -150,7 +157,7 @@ function renderSummaryTable(stations) {
         if (typeof start === 'string' && start.length > 10) start = start.replace('T', ' ');
         if (typeof end === 'string' && end.length > 10) end = end.replace('T', ' ');
         html += `<tr>
-            <td data-label='Network'><strong>${name}</strong></td>
+            <td data-label='Network'><strong>${name}</strong>${offlineBadge(station)}</td>
             <td data-label='Catalog Entries'>${entryCount}</td>
             <td data-label='Total Duration'>${totalDuration}</td>
             <td data-label='Schedule Start'>${start}</td>
@@ -271,6 +278,7 @@ window.fs42Common = {
     fetchStationSummary,
     fetchChannels,
     fetchCatalog,
+    offlineBadge,
     renderSummaryTable,
     renderCatalogTable,
     fetchScheduleSummary,

--- a/fs42/fs42_server/static/customguide/customguide.css
+++ b/fs42/fs42_server/static/customguide/customguide.css
@@ -389,3 +389,20 @@ body {
     );
 }
 
+
+.channel-name.channel-offline {
+  opacity: 0.55;
+}
+
+.offline-tag {
+  display: inline-block;
+  margin-left: 0.3em;
+  padding: 0 0.3em;
+  border-radius: 3px;
+  font-size: 0.55em;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  background: #da3633;
+  color: #fff;
+  vertical-align: middle;
+}

--- a/fs42/fs42_server/static/customguide/customguide.js
+++ b/fs42/fs42_server/static/customguide/customguide.js
@@ -137,6 +137,15 @@ function mockFetchAllSchedules(slots) {
   return schedules;
 }
 
+function markOffline(nameSpan, station) {
+  if (!station.channel_offline) return;
+  nameSpan.classList.add('channel-offline');
+  const tag = document.createElement('span');
+  tag.className = 'offline-tag';
+  tag.textContent = 'OFFLINE';
+  nameSpan.appendChild(tag);
+}
+
 async function fetchStations() {
   const all = await window.fs42Common.fetchChannels();
   stations = all.filter(s => !s.hidden);
@@ -203,6 +212,7 @@ function buildScrollStrip(slots, schedules) {
       nameSpan.className = 'channel-name';
       const name = station.network_name;
       nameSpan.textContent = name.length > 10 ? name.slice(0, 10) + '…' : name;
+      markOffline(nameSpan, station);
 
       channelInfo.appendChild(numSpan);
       channelInfo.appendChild(nameSpan);
@@ -429,6 +439,7 @@ function buildGridStrip(slots, schedules) {
     const nameSpan = document.createElement('span');
     nameSpan.className = 'channel-name';
     nameSpan.textContent = station.network_name;
+    markOffline(nameSpan, station);
 
     channelDiv.appendChild(numSpan);
     channelDiv.appendChild(nameSpan);

--- a/fs42/fs42_server/static/guide.css
+++ b/fs42/fs42_server/static/guide.css
@@ -401,3 +401,19 @@
         font-size: 0.55rem;
     }
 }
+.station-row.station-offline .network-name {
+    opacity: 0.55;
+}
+
+.offline-tag {
+    display: inline-block;
+    margin-left: 0.4em;
+    padding: 0 0.35em;
+    border-radius: 3px;
+    font-size: 0.6em;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    background: #da3633;
+    color: #fff;
+    vertical-align: middle;
+}

--- a/fs42/fs42_server/static/guide_frame.html
+++ b/fs42/fs42_server/static/guide_frame.html
@@ -277,11 +277,13 @@
             for (const station of stations) {
                 const channelNumber = station.channel_number || '?';
                 const displayName = station.network_long_name || station.network_name;
+                const offlineClass = station.channel_offline ? ' station-offline' : '';
+                const offlineTag = station.channel_offline ? '<span class="offline-tag">OFFLINE</span>' : '';
                 stationsHTML += `
-                    <div class="station-row">
+                    <div class="station-row${offlineClass}">
                         <div class="station-name">
                             <div class="channel-number">${channelNumber}</div>
-                            <div class="network-name">${displayName}</div>
+                            <div class="network-name">${displayName}${offlineTag}</div>
                         </div>
                     </div>
                 `;

--- a/fs42/fs42_server/static/station_ui.css
+++ b/fs42/fs42_server/static/station_ui.css
@@ -70,6 +70,31 @@
     letter-spacing: 0.5px;
 }
 
+.station-card-logo {
+    width: 48px;
+    height: 48px;
+    object-fit: contain;
+    flex: 0 0 48px;
+    align-self: center;
+    border-radius: 4px;
+    background: #0d1117;
+    border: 1px solid #30363d;
+}
+
+.station-card-status {
+    display: inline-block;
+    padding: 0.2em 0.6em;
+    border-radius: 3px;
+    font-size: 0.7em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.status-online  { background: #238636; color: #ffffff; }
+.status-offline { background: #da3633; color: #ffffff; }
+.status-always  { background: #1f6feb; color: #ffffff; }
+
 .station-card-draft {
     display: inline-block;
     padding: 0.2em 0.6em;

--- a/fs42/fs42_server/static/stations.html
+++ b/fs42/fs42_server/static/stations.html
@@ -15,6 +15,8 @@
     <script>
         let allStations = [];
         let filteredStations = [];
+        let channelStatus = {};
+        const STATUS_REFRESH_MS = 15000;
 
         // Initialize page layout
         document.addEventListener('DOMContentLoaded', async function() {
@@ -102,12 +104,45 @@
             document.body.innerHTML = await window.fs42Common.createPageLayout('', content);
 
             // Load stations
+            await loadStatus();
             await loadStations();
+            setInterval(async () => { await loadStatus(); renderStations(); }, STATUS_REFRESH_MS);
 
             // Setup event listeners
             document.getElementById('type-filter').addEventListener('change', applyFilters);
             document.getElementById('search-input').addEventListener('input', applyFilters);
         });
+
+        async function loadStatus() {
+            try {
+                const channels = await window.fs42Common.fetchChannels();
+                channelStatus = {};
+                for (const c of channels) channelStatus[c.network_name] = c;
+            } catch (e) {
+            }
+        }
+
+        function logoPath(station) {
+            if (!station.default_logo) return null;
+            const parts = [];
+            if (station.content_dir) parts.push(station.content_dir.replace(/\/+$/, ''));
+            if (station.logo_dir) parts.push(station.logo_dir.replace(/^\/+|\/+$/g, ''));
+            parts.push(station.default_logo);
+            return parts.join('/');
+        }
+
+        function statusBadge(station) {
+            const type = station.network_type || 'standard';
+            if (type !== 'web' && type !== 'streaming') return '';
+            if (station.always_available) {
+                return '<span class="station-card-status status-always" title="always_available: never treated as offline">always available</span>';
+            }
+            const st = channelStatus[station.network_name];
+            if (!st) return '';
+            return st.channel_offline
+                ? '<span class="station-card-status status-offline" title="URL(s) unreachable - skipped by channel up/down and hidden from the native guide">offline</span>'
+                : '<span class="station-card-status status-online">online</span>';
+        }
 
         async function loadStations() {
             try {
@@ -181,16 +216,22 @@
                 const draftReason = station._draft
                     ? `<div class="station-card-draft-reason">${escapeHtml(station._draft_reason || 'Configuration could not be loaded')}</div>`
                     : '';
+                const logo = logoPath(station);
+                const logoHtml = logo
+                    ? `<img class="station-card-logo" src="/media/image?path=${encodeURIComponent(logo)}" alt="" onerror="this.style.display='none'">`
+                    : '';
 
                 html += `
                     <div class="station-card">
                         <div class="station-card-header">
                             <div class="station-card-title-row">
+                                ${logoHtml}
                                 <h3 class="station-card-name">${name}</h3>
                                 <span class="station-card-channel">#${channel}</span>
                             </div>
                             <div class="station-card-meta">
                                 <span class="station-card-type station-type-${type}">${type}</span>
+                                ${statusBadge(station)}
                                 ${draftBadge}
                             </div>
                         </div>
@@ -235,8 +276,12 @@
                     return `Continuous loop<br><small style="color:#61afef;">${escapeHtml(dir)}</small>`;
 
                 case 'streaming':
-                    const streams = station.streams?.length || 0;
-                    return `External streams &bull; ${streams} source(s)`;
+                    const streamList = station.streams || [];
+                    const urls = streamList
+                        .filter(st => st && st.url)
+                        .map(st => `<small style="color:#61afef;">${escapeHtml(st.url)}</small>`)
+                        .join('<br>');
+                    return `External streams &bull; ${streamList.length} source(s)` + (urls ? `<br>${urls}` : '');
 
                 default:
                     return 'Custom configuration';

--- a/fs42/guide_builder.py
+++ b/fs42/guide_builder.py
@@ -107,8 +107,9 @@ class GuideBuilder:
             start_time = now.replace(minute=0, second=1, microsecond=0)
 
         # each statio is a row
-        for station in StationManager().stations:
-            if station["hidden"]:
+        manager = StationManager()
+        for station in manager.stations:
+            if manager.is_hidden(station):
                 continue
             elif not station["_has_schedule"]:
                 to_display = station.get("network_long_name", station["network_name"])

--- a/fs42/reachability.py
+++ b/fs42/reachability.py
@@ -1,0 +1,229 @@
+"""Reachability monitor for web and streaming channels.
+
+Web (``web_url``) and streaming (``streams[*].url``) stations depend on remote
+hosts. This module runs a small daemon thread that periodically TCP-connects to
+those hosts so the player, native guide and 4242 server can treat unreachable
+stations as offline (hide them from channel up/down, hide them from the native
+guide, badge them in the web UI).
+
+Design notes:
+- One monitor per *process*. The player, the forked guide channel process and
+  the FastAPI server process each get their own. ``get_monitor()`` restarts the
+  thread when it finds one that is not alive - a forked child inherits the
+  parent's borg dict but not its threads.
+- Probing is concurrent and de-duplicated by host:port so a cycle is bounded by
+  roughly one ``reachability_timeout`` regardless of how many stations/URLs are
+  configured. This matters most when the uplink is down and every probe fails.
+- A station whose reachability has not been checked yet is reported as
+  reachable (optimistic) so nothing flickers at startup.
+"""
+
+import logging
+import socket
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, wait
+from urllib.parse import urlparse
+
+PROBE_TYPES = ("web", "streaming")
+
+DEFAULT_PORTS = {
+    "http": 80,
+    "https": 443,
+    "rtsp": 554,
+    "rtsps": 322,
+    "rtmp": 1935,
+    "rtmps": 443,
+    "mms": 1755,
+    "udp": None,
+    "rtp": None,
+}
+
+_MONITOR_KEY = "_reachability_monitor"
+_MAX_PROBE_WORKERS = 8
+
+
+def probe_urls_for(station):
+    """Return the list of remote URLs a station depends on (may be empty)."""
+    ntype = station.get("network_type")
+    if ntype == "web":
+        url = station.get("web_url")
+        return [url] if url else []
+    if ntype == "streaming":
+        return [s.get("url") for s in (station.get("streams") or []) if isinstance(s, dict) and s.get("url")]
+    return []
+
+
+def probe_target_for(url):
+    """Map a URL to a (host, port) TCP target, or None if it can't be probed."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    host = parsed.hostname
+    if not host:
+        return None
+    scheme = (parsed.scheme or "http").lower()
+    if scheme in DEFAULT_PORTS and DEFAULT_PORTS[scheme] is None:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is None:
+        port = DEFAULT_PORTS.get(scheme, 80)
+    return (host, port)
+
+
+def tcp_probe(target, timeout):
+    host, port = target
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+    except Exception:
+        return False
+
+
+class ReachabilityMonitor:
+    def __init__(self, interval=30, timeout=5, name_prefix="ReachabilityMonitor"):
+        self.interval = max(1, int(interval))
+        self.timeout = max(0.5, float(timeout))
+        self._l = logging.getLogger("REACHABILITY")
+        self._lock = threading.Lock()
+        self._status = {}
+        self._first_check_done = threading.Event()
+        self._stop = threading.Event()
+        self._thread = None
+        self._name_prefix = name_prefix
+
+
+    def start(self):
+        if self._thread is not None and self._thread.is_alive():
+            return self
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, name=self._name_prefix, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self):
+        self._stop.set()
+
+    def is_alive(self):
+        return self._thread is not None and self._thread.is_alive()
+
+    def wait_first_check(self, timeout=None):
+        """Block until the first probe cycle completes (or timeout). Returns True if done."""
+        return self._first_check_done.wait(timeout)
+
+
+    def is_reachable(self, network_name):
+        with self._lock:
+            return self._status.get(network_name, True)
+
+    def snapshot(self):
+        with self._lock:
+            return dict(self._status)
+
+
+    def _run(self):
+        while not self._stop.is_set():
+            started = time.monotonic()
+            try:
+                self.check_once()
+            except Exception as e:
+                self._l.exception(f"Reachability check failed: {e}")
+            self._first_check_done.set()
+            elapsed = time.monotonic() - started
+            self._stop.wait(max(0.0, self.interval - elapsed))
+
+    def check_once(self, stations=None):
+        """Run one probe cycle. Returns the new {network_name: reachable} map."""
+        if stations is None:
+            from fs42.station_manager import StationManager
+
+            stations = StationManager().stations
+
+        plan = {}
+        targets = set()
+        for station in stations:
+            if station.get("network_type") not in PROBE_TYPES:
+                continue
+            name = station.get("network_name")
+            if station.get("always_available", False):
+                plan[name] = None
+                continue
+            station_targets = []
+            for url in probe_urls_for(station):
+                t = probe_target_for(url)
+                if t is not None:
+                    station_targets.append(t)
+                    targets.add(t)
+            plan[name] = station_targets
+
+        results = self._probe_targets(targets)
+
+        new_status = {}
+        for name, station_targets in plan.items():
+            if station_targets is None or len(station_targets) == 0:
+                new_status[name] = True
+            else:
+                new_status[name] = any(results.get(t, False) for t in station_targets)
+
+        with self._lock:
+            for name, reachable in new_status.items():
+                prev = self._status.get(name)
+                if prev is not None and prev != reachable:
+                    self._l.info(f"Channel '{name}' is now {'ONLINE' if reachable else 'OFFLINE'}")
+                elif prev is None and not reachable:
+                    self._l.warning(f"Channel '{name}' is OFFLINE (unreachable)")
+            self._status = new_status
+        return new_status
+
+    def _probe_targets(self, targets):
+        if not targets:
+            return {}
+        targets = list(targets)
+        results = {}
+        workers = min(_MAX_PROBE_WORKERS, len(targets))
+        pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="fs42-probe")
+        try:
+            futures = {pool.submit(tcp_probe, t, self.timeout): t for t in targets}
+            batches = -(-len(targets) // workers)
+            done, _ = wait(futures, timeout=self.timeout * batches + 1.0)
+            for fut in done:
+                try:
+                    results[futures[fut]] = bool(fut.result())
+                except Exception:
+                    results[futures[fut]] = False
+            for t in targets:
+                results.setdefault(t, False)
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
+        return results
+
+
+def get_monitor():
+    """Return the per-process monitor, starting (or restarting after fork) as needed."""
+    from fs42.station_manager import StationManager
+
+    manager = StationManager()
+    conf = manager.server_conf
+    monitor = manager.__dict__.get(_MONITOR_KEY)
+    if monitor is None or not monitor.is_alive():
+        if monitor is not None:
+            fresh = ReachabilityMonitor(
+                interval=conf.get("reachability_interval", 30),
+                timeout=conf.get("reachability_timeout", 5),
+            )
+            fresh._status = monitor.snapshot()
+            monitor = fresh
+        else:
+            monitor = ReachabilityMonitor(
+                interval=conf.get("reachability_interval", 30),
+                timeout=conf.get("reachability_timeout", 5),
+            )
+        monitor.start()
+        manager.__dict__[_MONITOR_KEY] = monitor
+    return monitor

--- a/fs42/station_config_schema.json
+++ b/fs42/station_config_schema.json
@@ -324,6 +324,10 @@
           "type": "string",
           "description": "URL for web-type networks"
         },
+        "always_available": {
+          "type": "boolean",
+          "description": "web and streaming networks only. If true the channel is never treated as offline - it stays in channel up/down navigation and the guide even when its URL(s) are unreachable (e.g. a locally hosted diagnostic channel). Defaults to false."
+        },
         "refresh_interval": {
           "type": "number",
           "minimum": 0,

--- a/fs42/station_manager.py
+++ b/fs42/station_manager.py
@@ -59,6 +59,9 @@ class StationManager(object):
                     "video_seek_timeout": 10,
                     "follow_static_symlinks": False,
                     "custom_holidays": {},
+                    "reachability_check": True,
+                    "reachability_interval": 30,
+                    "reachability_timeout": 5,
                 }
                 self._number_index = {}
                 self._name_index = {}
@@ -100,6 +103,28 @@ class StationManager(object):
         if channel_number in self._number_index:
             return self._number_index[channel_number]
         return None
+
+    def is_channel_offline(self, station):
+        """True when a web/streaming station's remote URL(s) are currently unreachable.
+
+        Stations of other types, stations flagged ``always_available`` and all
+        stations when ``reachability_check`` is disabled are never offline.
+        """
+        if station.get("always_available", False):
+            return False
+        if station.get("network_type") not in ("web", "streaming"):
+            return False
+        if not self.server_conf.get("reachability_check", True):
+            return False
+        from fs42.reachability import get_monitor
+
+        return not get_monitor().is_reachable(station["network_name"])
+
+    def is_hidden(self, station):
+        """Effective visibility for tuning and the native guide: config ``hidden`` OR offline."""
+        if station.get("hidden", False):
+            return True
+        return self.is_channel_offline(station)
 
     def index_from_channel(self, channel):
         index = 0
@@ -163,6 +188,9 @@ class StationManager(object):
                     "parental_controls_pin",
                     "parental_controls_theme",
                     "custom_holidays",
+                    "reachability_check",
+                    "reachability_interval",
+                    "reachability_timeout",
                 ]
 
                 for key in to_check:

--- a/test/test_reachability.py
+++ b/test/test_reachability.py
@@ -1,0 +1,284 @@
+import socket
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from fs42.station_manager import StationManager
+from fs42.station_io import StationIO
+from fs42 import reachability
+from fs42.reachability import (
+    ReachabilityMonitor,
+    probe_target_for,
+    probe_urls_for,
+    get_monitor,
+)
+
+
+def _reset_manager(server_conf_overrides=None):
+    StationManager._StationManager__we_are_all_one = {}
+    StationManager._initialized = False
+    StationManager.stations = []
+    config_data = {"server_port": 4242}
+    if server_conf_overrides:
+        config_data.update(server_conf_overrides)
+    with patch.object(StationIO, "load_main_config", return_value=config_data):
+        with patch("fs42.station_io.glob.glob", return_value=[]):
+            return StationManager()
+
+
+def _station(name, ntype, **extra):
+    d = {"network_name": name, "network_type": ntype, "channel_number": 1, "hidden": False}
+    d.update(extra)
+    return d
+
+
+
+class TestProbeUrls:
+    def test_web_uses_web_url(self):
+        assert probe_urls_for(_station("w", "web", web_url="https://example.com/x")) == ["https://example.com/x"]
+
+    def test_web_without_url_is_empty(self):
+        assert probe_urls_for(_station("w", "web")) == []
+
+    def test_streaming_collects_all_stream_urls(self):
+        st = _station("s", "streaming", streams=[
+            {"url": "https://a.example/1.m3u8", "duration": 30, "title": "a"},
+            {"url": "rtsp://b.example/live", "duration": 30, "title": "b"},
+            {"duration": 30, "title": "no url"},
+        ])
+        assert probe_urls_for(st) == ["https://a.example/1.m3u8", "rtsp://b.example/live"]
+
+    def test_streaming_without_streams_is_empty(self):
+        assert probe_urls_for(_station("s", "streaming")) == []
+        assert probe_urls_for(_station("s", "streaming", streams=[])) == []
+
+    @pytest.mark.parametrize("ntype", ["standard", "loop", "guide", "executable"])
+    def test_other_types_have_nothing_to_probe(self, ntype):
+        assert probe_urls_for(_station("x", ntype, web_url="https://example.com")) == []
+
+
+class TestProbeTarget:
+    @pytest.mark.parametrize("url,expected", [
+        ("https://example.com/a.m3u8", ("example.com", 443)),
+        ("http://example.com/a", ("example.com", 80)),
+        ("http://example.com:8080/a", ("example.com", 8080)),
+        ("rtsp://cam.local/live", ("cam.local", 554)),
+        ("rtmp://cdn.example/app", ("cdn.example", 1935)),
+        ("udp://239.0.0.1:1234", None),
+        ("not a url", None),
+        ("", None),
+    ])
+    def test_targets(self, url, expected):
+        assert probe_target_for(url) == expected
+
+
+
+class TestMonitorCheckOnce:
+    def _probe_map(self, up_hosts):
+        def fake(target, timeout):
+            return target[0] in up_hosts
+        return fake
+
+    def test_unknown_is_optimistic(self):
+        m = ReachabilityMonitor()
+        assert m.is_reachable("nope") is True
+
+    def test_web_offline_when_host_down(self):
+        m = ReachabilityMonitor()
+        stations = [_station("w", "web", web_url="https://down.example/")]
+        with patch.object(reachability, "tcp_probe", self._probe_map(set())):
+            status = m.check_once(stations)
+        assert status == {"w": False}
+        assert m.is_reachable("w") is False
+
+    def test_web_online_when_host_up(self):
+        m = ReachabilityMonitor()
+        stations = [_station("w", "web", web_url="https://up.example/")]
+        with patch.object(reachability, "tcp_probe", self._probe_map({"up.example"})):
+            assert m.check_once(stations) == {"w": True}
+
+    def test_streaming_reachable_if_any_stream_up(self):
+        m = ReachabilityMonitor()
+        st = _station("s", "streaming", streams=[
+            {"url": "https://down1.example/a"},
+            {"url": "https://up.example/b"},
+            {"url": "https://down2.example/c"},
+        ])
+        with patch.object(reachability, "tcp_probe", self._probe_map({"up.example"})):
+            assert m.check_once([st]) == {"s": True}
+
+    def test_streaming_offline_if_all_streams_down(self):
+        m = ReachabilityMonitor()
+        st = _station("s", "streaming", streams=[{"url": "https://d1.example/a"}, {"url": "https://d2.example/b"}])
+        with patch.object(reachability, "tcp_probe", self._probe_map(set())):
+            assert m.check_once([st]) == {"s": False}
+
+    def test_always_available_skips_probe_and_is_reachable(self):
+        m = ReachabilityMonitor()
+        st = _station("diag", "web", web_url="http://localhost:4242/static/diagnostics.html", always_available=True)
+        calls = []
+
+        def fake(target, timeout):
+            calls.append(target)
+            return False
+
+        with patch.object(reachability, "tcp_probe", fake):
+            assert m.check_once([st]) == {"diag": True}
+        assert calls == []
+
+    def test_no_urls_is_reachable(self):
+        m = ReachabilityMonitor()
+        with patch.object(reachability, "tcp_probe", self._probe_map(set())):
+            assert m.check_once([_station("w", "web"), _station("s", "streaming", streams=[])]) == {"w": True, "s": True}
+
+    def test_non_remote_types_not_tracked(self):
+        m = ReachabilityMonitor()
+        with patch.object(reachability, "tcp_probe", self._probe_map(set())):
+            assert m.check_once([_station("std", "standard"), _station("g", "guide")]) == {}
+        assert m.is_reachable("std") is True
+
+    def test_targets_are_deduplicated_across_stations(self):
+        m = ReachabilityMonitor()
+        seen = []
+
+        def fake(target, timeout):
+            seen.append(target)
+            return True
+
+        stations = [
+            _station("a", "web", web_url="https://same.example/a"),
+            _station("b", "web", web_url="https://same.example/b"),
+            _station("c", "streaming", streams=[{"url": "https://same.example/c.m3u8"}]),
+        ]
+        with patch.object(reachability, "tcp_probe", fake):
+            m.check_once(stations)
+        assert seen == [("same.example", 443)]
+
+    def test_real_tcp_probe_against_local_listener(self):
+        srv = socket.socket()
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        try:
+            m = ReachabilityMonitor(timeout=1)
+            up = _station("up", "web", web_url=f"http://127.0.0.1:{port}/")
+            assert m.check_once([up]) == {"up": True}
+        finally:
+            srv.close()
+        m2 = ReachabilityMonitor(timeout=1)
+        assert m2.check_once([up]) == {"up": False}
+
+
+class TestMonitorThread:
+    def test_start_runs_first_check_and_sets_event(self):
+        m = ReachabilityMonitor(interval=60, timeout=1)
+        st = _station("w", "web", web_url="https://x.example/")
+        manager = _reset_manager()
+        manager.stations = [st]
+        with patch.object(reachability, "tcp_probe", lambda t, to: False):
+            m.start()
+            assert m.wait_first_check(timeout=5)
+            assert m.is_reachable("w") is False
+            m.stop()
+
+
+class TestGetMonitor:
+    def test_get_monitor_is_per_process_singleton(self):
+        manager = _reset_manager()
+        manager.stations = []
+        m1 = get_monitor()
+        m2 = get_monitor()
+        assert m1 is m2
+        assert m1.is_alive()
+        m1.stop()
+
+    def test_get_monitor_restarts_dead_thread_and_keeps_status(self):
+        manager = _reset_manager()
+        st = _station("w", "web", web_url="https://down.example/")
+        manager.stations = [st]
+        dead = ReachabilityMonitor()
+        dead._status = {"w": False}
+        dead._thread = threading.Thread(target=lambda: None)
+        dead._thread.start()
+        dead._thread.join()
+        manager.__dict__[reachability._MONITOR_KEY] = dead
+        with patch.object(reachability, "tcp_probe", lambda t, to: False):
+            fresh = get_monitor()
+            assert fresh is not dead
+            assert fresh.is_alive()
+            assert fresh.is_reachable("w") is False
+            assert fresh.wait_first_check(timeout=5)
+            assert fresh.is_reachable("w") is False
+            assert manager.is_hidden(st) is True
+            fresh.stop()
+
+    def test_get_monitor_uses_server_conf(self):
+        manager = _reset_manager({"reachability_interval": 7, "reachability_timeout": 2})
+        manager.stations = []
+        m = get_monitor()
+        assert m.interval == 7
+        assert m.timeout == 2
+        m.stop()
+
+
+
+class TestStationManagerVisibility:
+    def test_defaults_loaded(self):
+        manager = _reset_manager()
+        assert manager.server_conf["reachability_check"] is True
+        assert manager.server_conf["reachability_interval"] == 30
+        assert manager.server_conf["reachability_timeout"] == 5
+
+    def test_main_config_overrides(self):
+        manager = _reset_manager({"reachability_check": False, "reachability_interval": 10})
+        assert manager.server_conf["reachability_check"] is False
+        assert manager.server_conf["reachability_interval"] == 10
+
+    def test_offline_web_station_is_hidden(self):
+        manager = _reset_manager()
+        st = _station("w", "web", web_url="https://down.example/")
+        manager.stations = [st]
+        m = get_monitor()
+        with patch.object(reachability, "tcp_probe", lambda t, to: False):
+            m.check_once([st])
+        assert manager.is_channel_offline(st) is True
+        assert manager.is_hidden(st) is True
+        m.stop()
+
+    def test_config_hidden_still_hidden_when_online(self):
+        manager = _reset_manager()
+        st = _station("w", "web", web_url="https://up.example/", hidden=True)
+        manager.stations = [st]
+        m = get_monitor()
+        with patch.object(reachability, "tcp_probe", lambda t, to: True):
+            m.check_once([st])
+        assert manager.is_channel_offline(st) is False
+        assert manager.is_hidden(st) is True
+        m.stop()
+
+    def test_always_available_never_offline(self):
+        manager = _reset_manager()
+        st = _station("diag", "web", web_url="http://localhost:1/", always_available=True)
+        manager.stations = [st]
+        m = get_monitor()
+        with patch.object(reachability, "tcp_probe", lambda t, to: False):
+            m.check_once([st])
+        assert manager.is_channel_offline(st) is False
+        assert manager.is_hidden(st) is False
+        m.stop()
+
+    def test_reachability_check_disabled_never_offline(self):
+        manager = _reset_manager({"reachability_check": False})
+        st = _station("w", "web", web_url="https://down.example/")
+        manager.stations = [st]
+        assert manager.is_channel_offline(st) is False
+        assert manager.is_hidden(st) is False
+        assert reachability._MONITOR_KEY not in manager.__dict__
+
+    def test_standard_station_never_offline(self):
+        manager = _reset_manager()
+        st = _station("std", "standard")
+        manager.stations = [st]
+        assert manager.is_channel_offline(st) is False
+        assert reachability._MONITOR_KEY not in manager.__dict__


### PR DESCRIPTION
Sometimes I leave the house... and like to bring my FieldStation42 along with me. So I wanted to help make the project a bit more resilient to being off-grid.  Web or streaming channel with no connectivity still appear in the channel lineup and the guide when offline, so flipping through channels without internet meant landing on blank channels. To help on that front, and keep the guide and available channels accurate to what is available wherever the FieldStation is: web and streaming channels whose hosts can't be reached are dynamically hidden, and come back automatically when connectivity returns. 

How it works: 
A monitor (fs42/reachability.py) conducts a TCP probe on the host:port of each web station's web_url and streaming station's streams url each reachability_interval seconds (default 30, timeout 5). A station where all of their  URLs are unreachable is treated as offline:

Offline effects are:
- skipped during channel up/down changes
- drop channel from the guide channel
- Flagged as OFFLINE in the web UI (Home Station Summary & Stations tab), so the config side always shows the full lineup

A channel that you do not want to have monitored (like maybe diagnostics or WeatherStar) can opt out per channel with "always_available": true option in the channel confs/*.json. Putting reachability_check: false in main_config.json would disable the feature completely.

Details:
- StationManager: reachability_check / reachability_interval / reachability_timeout options; is_channel_offline() and is_hidden() (config hidden OR offline)
- field_player: start the monitor early; channel up/down use is_hidden() and are bounded (no infinite loop when every station is hidden); the start channel advances past any offline web/streaming station
- guide_builder: native guide uses is_hidden()
- API: /summary and /summary/channels add channel_offline and network_type; new GET /media/image?path= for station logos
- Stations page: logo thumbnail per card, ONLINE / OFFLINE / ALWAYS AVAILABLE badge on web/streaming cards (refreshed every 15 s), stream URLs listed on streaming cards
- Schema, docs as well as an example diagnostics conf for always_available
- The monitor restarts itself so the guide and API processes stay current; probes run concurrently and are de-duplicated by host:port incase of multiple web or stream channels to same host
- 37 unit tests in test/test_reachability.py